### PR TITLE
Don't define _GNU_SOURCE if already defined.

### DIFF
--- a/code/config.h
+++ b/code/config.h
@@ -356,7 +356,10 @@
 #if defined(MPS_OS_LI)
 
 #define _XOPEN_SOURCE 500
+
+#ifndef _GNU_SOURCE
 #define _GNU_SOURCE
+#endif
 
 #endif
 


### PR DESCRIPTION
When using the build method of including the MPS directly into
one's own sources, that build system may already define _GNU_SOURCE
causing a warning here about re-defining it.
