### PR TITLE
Define WIN32_LEAN_AND_MEAN when including windows.h.

### DIFF
--- a/code/clock.h
+++ b/code/clock.h
@@ -49,6 +49,7 @@ typedef union EventClockUnion {
    using Microsoft Visual Studio 6 because of support for CodeView debugging
    information. */
 
+#define WIN32_LEAN_AND_MEAN
 #include <windows.h> /* KILL IT WITH FIRE! */
 
 #define EVENT_CLOCK(lvalue) \

--- a/code/mpsw3.h
+++ b/code/mpsw3.h
@@ -11,6 +11,7 @@
 #define mpsw3_h
 
 #include "mps.h"               /* needed for mps_tramp_t */
+#define WIN32_LEAN_AND_MEAN
 #include <windows.h>           /* needed for SEH filter */
 
 

--- a/code/mpswin.h
+++ b/code/mpswin.h
@@ -16,6 +16,7 @@
 #pragma warning(disable: 4115 4201 4209 4214)
 #endif
 
+#define WIN32_LEAN_AND_MEAN
 #include <windows.h>
 
 #ifdef MPS_BUILD_MV


### PR DESCRIPTION
This results in a slimmer set of Windows headers being included.
