### PR TITLE
Use correct function for creating arena

### DIFF
--- a/test/function/7.c
+++ b/test/function/7.c
@@ -19,7 +19,7 @@ static void test(void *stack_pointer)
 
  for (p=0; p<ARENAS; p++)
  {
-  die(mps_arena_create(&arena, mps_arena_class_vm(), mps_args_none), "create");
+  die(mps_arena_create_k(&arena, mps_arena_class_vm(), mps_args_none), "create");
   if (p > 0)
    mps_arena_destroy(arena1);
   arena1=arena;


### PR DESCRIPTION
Fixes #16 (MMQA test function/7.c fails with RESOURCE)

Since we are passing a list of keyword arguments, we must call the keyword-taking function (`mps_arena_create_k`) and not the deprecated varargs function (`mps_arena_create`).