### PR TITLE
Set SA_RESTART flag when calling sigaction().

### DIFF
--- a/code/protsgix.c
+++ b/code/protsgix.c
@@ -135,7 +135,7 @@ void ProtSetup(void)
 
   sa.sa_sigaction = sigHandle;
   sigemptyset(&sa.sa_mask);
-  sa.sa_flags = SA_SIGINFO;
+  sa.sa_flags = SA_SIGINFO | SA_RESTART;
 
   result = sigaction(PROT_SIGNAL, &sa, &sigNext);
   AVER(result == 0);

--- a/code/pthrdext.c
+++ b/code/pthrdext.c
@@ -140,9 +140,9 @@ static void PThreadextModuleInit(void)
     status = sigaddset(&pthreadext_sigsuspend.sa_mask, PTHREADEXT_SIGRESUME);
     AVER(status == 0);
 
-    pthreadext_sigsuspend.sa_flags = SA_SIGINFO;
+    pthreadext_sigsuspend.sa_flags = SA_SIGINFO | SA_RESTART;
     pthreadext_sigsuspend.sa_sigaction = suspendSignalHandler;
-    pthreadext_sigresume.sa_flags = 0;
+    pthreadext_sigresume.sa_flags = SA_RESTART;
     pthreadext_sigresume.sa_handler = resumeSignalHandler;
     status = sigemptyset(&pthreadext_sigresume.sa_mask);
     AVER(status == 0);

--- a/design/protix.txt
+++ b/design/protix.txt
@@ -50,9 +50,27 @@ Functions
 
 _`.fun.setup`: ``ProtSetup()`` installs a signal handler for the
 signal ``SIGSEGV`` to catch and handle protection faults (this handler
-is the function ``sigHandle()``). The previous handler is recorded (in
-the variable ``sigNext``, see `.data.signext`_) so that it can be
-reached from ``sigHandle()`` if it fails to handle the fault.
+is the function ``sigHandle()``).
+
+_`.fun.setup.previous`: The previous handler is recorded (in the
+variable ``sigNext``, see `.data.signext`_) so that it can be reached
+from ``sigHandle()`` if it fails to handle the fault.
+
+_`.fun.setup.restart`: We set the ``SA_RESTART`` flag when installing
+the signal handler so that if the mutator gets a protection fault
+while blocked in a system call, the system call is automatically
+restarted after the signal is handled, instead of failing with
+``EINTR``. Note that unlike the corresponding case in the thread
+management subsystem (see design.mps.thread-manager.req.thread.intr_)
+we are unsure if this case can actually arise: the ``SIGSEGV`` from a
+protection fault is delivered to the thread that accessed the
+protected memory, but in all the cases we have checked, if this access
+occurred during a blocking system call such as a ``read()`` with the
+buffer in protected memory, the system call fails with ``EFAULT`` and
+is not restarted. However, it costs us nothing to set the
+``SA_RESTART`` flag.
+
+.. _design.mps.thread-manager.req.thread.intr: thread-manager#.req.thread.intr
 
 _`.fun.set`: ``ProtSet()`` uses ``mprotect()`` to adjust the
 protection for pages.

--- a/design/thread-manager.txt
+++ b/design/thread-manager.txt
@@ -63,6 +63,13 @@ request.dylan.160022_ and request.mps.160093_.)
 .. _request.dylan.160022: https://info.ravenbrook.com/project/mps/import/2001-11-05/mmprevol/request/dylan/160022
 .. _request.mps.160093: https://info.ravenbrook.com/project/mps/import/2001-11-05/mmprevol/request/mps/160093/
 
+_`.req.thread.intr`: It would be nice if on POSIX systems the MPS does
+not cause system calls in the mutator to fail with EINTR due to the
+MPS thread-management signals being delivered while the mutator is
+blocked in a system call. (See `GitHub issue #9`_.)
+
+.. _GitHub issue #9: https://github.com/ravenbrook/mps/issues/9
+
 
 Design
 ------
@@ -94,6 +101,25 @@ _`.sol.thread.term.attempt`: Nonetheless, the thread manager makes a
 "best effort" to continue running after detecting a terminated thread,
 by moving the thread to a ring of dead threads, and avoiding scanning
 it. This might allow a malfunctioning client program to limp along.
+
+_`.sol.thread.intr`: The POSIX specification for sigaction_ says that
+if the ``SA_RESTART`` flag is set, and if "a function specified as
+interruptible is interrupted by this signal, the function shall
+restart and shall not fail with ``EINTR`` unless otherwise specified."
+
+.. |sigaction| replace:: ``sigaction()``
+.. _sigaction: https://pubs.opengroup.org/onlinepubs/9699919799/functions/sigaction.html
+
+_`.sol.thread.intr.linux`: Linux does not fully implement the POSIX
+specification, so that some system calls are "never restarted after
+being interrupted by a signal handler, regardless of the use of
+SA_RESTART; they always fail with the error EINTR when interrupted by
+a signal handler". The exceptional calls are listed in the |signal|_
+manual. There is nothing that the MPS can do about this except to warn
+users in the reference manual.
+
+.. |signal| replace:: signal(7)
+.. _signal: https://man7.org/linux/man-pages/man7/signal.7.html
 
 
 Interface

--- a/manual/source/release.rst
+++ b/manual/source/release.rst
@@ -57,6 +57,15 @@ Interface changes
    .. _struct: https://docs.python.org/3/library/struct.html#struct.unpack
 
 
+Other changes
+.............
+
+#. On FreeBSD and Linux, if the MPS handles a signal while the client
+   program is blocked in a system call, the system call is
+   automatically restarted and does not fail with ``EINTR``. See
+   :ref:`topic-thread-signal`.
+
+
 .. _release-notes-1.117:
 
 Release 1.117.0

--- a/manual/source/topic/thread.rst
+++ b/manual/source/topic/thread.rst
@@ -94,6 +94,18 @@ Signal and exception handling issues
 
             cc -DCONFIG_PTHREADEXT_SIGSUSPEND=SIGUSR2 -c mps.c
 
+    The MPS sets the :c:data:`SA_RESTART` flag when installing the
+    handlers for these signals, so that most blocking system calls are
+    automatically restarted after the delivery of the signal. However,
+    on Linux, not all blocking system calls are automatically
+    restarted after a signal is handle, so the :term:`client program`
+    must be prepared to handle :c:data:`EINTR` from :c:func:`poll`,
+    :c:func:`nanosleep` and so on. See the |signal|_ manual for a list
+    of affected system calls.
+
+    .. |signal| replace:: signal(7)
+    .. _signal: https://man7.org/linux/man-pages/man7/signal.7.html
+
 .. warning::
 
     The MPS uses :term:`barriers (1)` to :term:`protect <protection>`

--- a/test/function/236.c
+++ b/test/function/236.c
@@ -1,0 +1,155 @@
+/*
+TEST_HEADER
+ id = $Id$
+ summary = regression test for GitHub issue #9
+ language = c
+ link = testlib.o myfmt.o
+ parameters =
+END_HEADER
+*/
+
+#if !defined(MPS_OS_FR) && !defined(MPS_OS_LI)
+
+#include "testlib.h"
+
+static void test(void *stack_pointer)
+{
+  /* nothing to do on non-POSIX systems */
+}
+
+#else
+
+#define _POSIX_C_SOURCE 199309L /* for nanosleep */
+
+#include "mpsavm.h"
+#include "mpscamc.h"
+#include "myfmt.h"
+#include "testlib.h"
+
+#include <errno.h>
+#include <pthread.h>
+#include <semaphore.h>
+#include <string.h>
+#include <unistd.h>
+
+/* On POSIX systems, the MPS suspends threads by sending them a signal
+ * (see PThreadextSuspend in pthrdext.c). If the signal was delivered
+ * while the mutator was blocked in a system call like open() or
+ * read() then the system call could formerly fail with EINTR.
+ *
+ * The test creates a thread. The thread registers itself with the
+ * MPS, posts on a semaphore to synchronize with the main thread, and
+ * then blocks itself in a read() system call. The main thread then
+ * calls mps_arena_collect() to cause the MPS to suspend all other
+ * threads. If the issue is not fixed, then the read() call on the
+ * thread fails with EINTR. Alternatively, if the issue is fixed, the
+ * read() call is automatically restarted, the main thread writes to
+ * the other end of the pipe so that the read() call completes, and we
+ * tear everything down.
+ */
+
+typedef struct test_data_s {
+  mps_arena_t arena;            /* The arena. */
+  sem_t *sem;                   /* Semaphore to post once registered. */
+  int fd;                       /* File descriptor to read from. */
+} test_data_t;
+
+static void *thread_fn(void *arg)
+{
+  test_data_t *data = arg;
+  mps_thr_t thread;
+  int e;
+  char c;
+
+  die(mps_thread_reg(&thread, data->arena), "mps_thread_reg");
+  e = sem_post(data->sem);
+  asserts(e == 0, "sem_post: %s", strerror(errno));
+
+  /* There is a race here: if MPS goes ahead with the collection on
+   * the main thread and manages to signal this thread before the
+   * read() system call is entered, then the test condition is not
+   * exercised (no opportunity for read() to fail with EINTR). This is
+   * an acceptable race because it doesn't make the test fail, it just
+   * fails to exercise the test condition.
+   *
+   * POSIX doesn't provide us with a portable way to ensure that the
+   * thread has blocked in the system call before starting the
+   * collection; on Linux we could poll /proc/TID/stat until the
+   * thread enters state S (sleeping in an interruptible wait) but
+   * this seems like a lot of trouble for a nice-to-have feature.
+   */
+  e = read(data->fd, &c, 1);
+  asserts(e == 1, "read: %d: %s", e, strerror(errno));
+  mps_thread_dereg(thread);
+  return NULL;
+}
+
+static void test(void *stack_pointer)
+{
+  mps_arena_t arena;
+  mps_fmt_t format;
+  mps_pool_t pool;
+  int pipefd[2];
+  int e;
+  sem_t sem;
+  test_data_t data;
+  pthread_t pthread;
+  struct timespec timespec = { 0, 1000000 };
+
+  die(mps_arena_create_k(&arena, mps_arena_class_vm(), mps_args_none), "mps_arena_create_k");
+  die(mps_fmt_create_A(&format, arena, &fmtA), "create format");
+  MPS_ARGS_BEGIN(args) {
+     MPS_ARGS_ADD(args, MPS_KEY_FORMAT, format);
+     die(mps_pool_create_k(&pool, arena, mps_class_amc(), args), "mps_pool_create_k");
+  } MPS_ARGS_END(args);
+
+  /* Create data structures for synchronizing with the thread. */
+  e = pipe(pipefd);
+  asserts(e == 0, "pipe: %s", strerror(errno));
+  e = sem_init(&sem, 0, 0);
+  asserts(e == 0, "sem_init: %s", strerror(errno));
+  data.arena = arena;
+  data.sem = &sem;
+  data.fd = pipefd[0];
+
+  /* Start the thread. */
+  e = pthread_create(&pthread, NULL, thread_fn, &data);
+  asserts(e == 0, "pthread_create: %s", strerror(e));
+
+  /* Wait for the thread to register itself. */
+  e = sem_wait(&sem);
+  asserts(e == 0, "sem_wait: %s", strerror(errno));
+
+  /* Delay to give the thread more time to block in read(). */
+  e = nanosleep(&timespec, NULL);
+  asserts(e == 0, "nanosleep: %s", strerror(errno));
+
+  /* Run a collection: this causes the MPS to suspend the thread via
+   * ArenaCollect, ArenaStartCollect, TraceStartCollectAll,
+   * TraceCondemnEnd, ShieldHold, shieldSuspend, ThreadRingSuspend, and
+   * PThreadextSuspend. */
+  mps_arena_collect(arena);
+
+  /* Write to the pipe so that the thread can complete its read. */
+  e = write(pipefd[1], "x", 1);
+  asserts(e == 1, "write: %s", strerror(errno));
+
+  /* Wait for the thread to complete. */
+  e = pthread_join(pthread, NULL);
+  asserts(e == 0, "pthread_join: %s", strerror(e));
+
+  /* Tear down MPS data structures. */
+  mps_arena_park(arena);
+  mps_pool_destroy(pool);
+  mps_fmt_destroy(format);
+  mps_arena_destroy(arena);
+}
+
+#endif
+
+int main(void)
+{
+  run_test(test);
+  pass();
+  return 0;
+}


### PR DESCRIPTION
Fixes #9 (Signal handling results in mutator getting `EINTR` for system calls)

Ensure that if a mutator thread is blocked in a system call when the MPS handles a signal, the system call will not fail with `EINTR` but instead will be restarted.

Add a test case for the thread suspend and resume signals.