### PR TITLE
Update the debugging examples in the User Guide.

### DIFF
--- a/manual/source/guide/debug.rst
+++ b/manual/source/guide/debug.rst
@@ -134,7 +134,7 @@ General debugging advice
    :c:func:`mps_arena_postmortem` from the debugger. This unlocks the
    arena and turns off protection.
 
-   .. warning:: 
+   .. warning::
 
        After calling :c:func:`mps_arena_postmortem`, MPS-managed
        memory is not in a consistent state, and so it is not safe to
@@ -254,9 +254,10 @@ in the Scheme interpreter's :ref:`scan method <guide-lang-scan>`, I
 might have forgotten to fix the first element of a pair:
 
 .. code-block:: c
-    :emphasize-lines: 2
+    :emphasize-lines: 3
 
     case TYPE_PAIR:
+    case TYPE_PROMISE:
       /* oops, forgot: FIX(CAR(obj)); */
       FIX(CDR(obj));
       base = (char *)base + ALIGN_OBJ(sizeof(pair_s));
@@ -273,45 +274,48 @@ MPS internal control structure.
 The reproducible test case is simple. Run a garbage collection by
 calling ``(gc)`` and then evaluate any expression::
 
-    $ gdb ./scheme
-    GNU gdb 6.3.50-20050815 (Apple version gdb-1820) (Sat Jun 16 02:40:11 UTC 2012)
-
+    $ gdb -q ./scheme
+    Reading symbols from ./scheme...done.
     (gdb) run
-    Starting program: example/scheme/scheme 
-    Reading symbols for shared libraries +............................. done
+    Starting program: /home/grees/github.com/mps/example/scheme/scheme
     MPS Toy Scheme Example
-    7944, 0> (gc)
+    The prompt shows total allocated bytes and number of collections.
+    Try (vector-length (make-vector 100000 1)) to see the MPS in action.
+    You can force a complete garbage collection with (gc).
+    If you recurse too much the interpreter may crash from using too much C stack.
+    13248, 0> (gc)
     Collection started.
       Why: Client requests: immediate full collection.
-      Clock: 11357
+      Clock: 1819
     Collection finished.
-        live 1888
-        condemned 7968
+        live 5272
+        condemned 16384
         not_condemned 0
-        clock: 12008
-    7968, 1> foo
-    Assertion failed: (TYPE(frame) == TYPE_PAIR), function lookup_in_frame, file scheme.c, line 1065.
+        clock: 1987
+    13272, 1> foo
+    scheme: scheme.c:1421: lookup_in_frame: Assertion `TYPE(CAAR(frame)) == TYPE_SYMBOL' failed.
 
     Program received signal SIGABRT, Aborted.
-    0x00007fff91aeed46 in __kill ()
+    __GI_raise (sig=sig@entry=6) at ../sysdeps/unix/sysv/linux/raise.c:51
+    51	../sysdeps/unix/sysv/linux/raise.c: No such file or directory.
 
 What's going on? ::
 
     (gdb) backtrace
-    #0  0x00007fff91aeed46 in __kill ()
-    #1  0x00007fff90509df0 in abort ()
-    #2  0x00007fff9050ae2a in __assert_rtn ()
-    #3  0x0000000100003f55 in lookup_in_frame (frame=0x1003fa7d0, symbol=0x1003faf20) at scheme.c:1066
-    #4  0x0000000100003ea6 in lookup (env=0x1003fb130, symbol=0x1003faf20) at scheme.c:1087
-    #5  0x000000010000341f in eval (env=0x1003fb130, op_env=0x1003fb148, exp=0x1003faf20) at scheme.c:1135
-    #6  0x000000010000261b in start (p=0x0, s=0) at scheme.c:3204
-    #7  0x0000000100011ded in ProtTramp (resultReturn=0x7fff5fbff7d0, f=0x100002130 <start>, p=0x0, s=0) at protix.c:132
-    #8  0x0000000100001ef7 in main (argc=1, argv=0x7fff5fbff830) at scheme.c:3314
+    #0  __GI_raise (sig=sig@entry=6) at ../sysdeps/unix/sysv/linux/raise.c:51
+    #1  0x00007ffff78058b1 in __GI_abort () at abort.c:79
+    #2  0x00007ffff77f542a in __assert_fail_base (fmt=0x7ffff797ca38 "%s%s%s:%u: %s%sAssertion `%s' failed.\n%n", assertion=assertion@entry=0x555555604050 "TYPE(CAAR(frame)) == TYPE_SYMBOL", file=file@entry=0x555555603bb2 "scheme.c", line=line@entry=1421, function=function@entry=0x555555605390 <__PRETTY_FUNCTION__.3661> "lookup_in_frame") at assert.c:92
+    #3  0x00007ffff77f54a2 in __GI___assert_fail (assertion=0x555555604050 "TYPE(CAAR(frame)) == TYPE_SYMBOL", file=0x555555603bb2 "scheme.c", line=1421, function=0x555555605390 <__PRETTY_FUNCTION__.3661> "lookup_in_frame") at assert.c:101
+    #4  0x000055555555d0d8 in lookup_in_frame (frame=0x7ffff5900bb8, symbol=0x7ffff5883418) at scheme.c:1421
+    #5  0x000055555555d16c in lookup (env=0x7ffff5880180, symbol=0x7ffff5883418) at scheme.c:1440
+    #6  0x000055555555d2d1 in eval (env=0x7ffff5880180, op_env=0x7ffff5880198, exp=0x7ffff5883418) at scheme.c:1487
+    #7  0x0000555555564f29 in start (argc=0, argv=0x7fffffffe0d0) at scheme.c:4341
+    #8  0x0000555555565717 in main (argc=0, argv=0x7fffffffe0d0) at scheme.c:4489
     (gdb) frame 4
-    #4  0x0000000100003ea6 in lookup (env=0x1003fb130, symbol=0x1003faf20) at scheme.c:1087
-    1086            binding = lookup_in_frame(CAR(env), symbol);
+    #4  0x000055555555d0d8 in lookup_in_frame (frame=0x7ffff5900bb8, symbol=0x7ffff5883418) at scheme.c:1421
+    1421	    assert(TYPE(CAAR(frame)) == TYPE_SYMBOL);
     (gdb) print (char *)symbol->symbol.string
-    $1 = 0x1003faf30 "foo"
+    $1 = 0x7ffff5883428 "foo"
 
 The backtrace shows that the interpreter is in the middle of looking
 up the symbol ``foo`` in the environment. The Scheme interpreter
@@ -330,29 +334,26 @@ there is only one frame in the environment (the global frame). And
 it's this frame that's corrupt:
 
 .. code-block:: none
-    :emphasize-lines: 10
+    :emphasize-lines: 7
 
-    (gdb) frame 3
-    #3  0x0000000100003f55 in lookup_in_frame (frame=0x1003fa7d0, symbol=0x1003faf20) at scheme.c:1066
-    1066            assert(TYPE(frame) == TYPE_PAIR);
     (gdb) list
-    1061         */
-    1062        
-    1063        static obj_t lookup_in_frame(obj_t frame, obj_t symbol)
-    1064        {
-    1065          while(frame != obj_empty) {
-    1066            assert(TYPE(frame) == TYPE_PAIR);
-    1067            assert(TYPE(CAR(frame)) == TYPE_PAIR);
-    1068            assert(TYPE(CAAR(frame)) == TYPE_SYMBOL);
-    1069            if(CAAR(frame) == symbol)
-    1070              return CAR(frame);
-    (gdb) print frame->type.type
-    $2 = 13
+    1416	static obj_t lookup_in_frame(obj_t frame, obj_t symbol)
+    1417	{
+    1418	  while(frame != obj_empty) {
+    1419	    assert(TYPE(frame) == TYPE_PAIR);
+    1420	    assert(TYPE(CAR(frame)) == TYPE_PAIR);
+    1421	    assert(TYPE(CAAR(frame)) == TYPE_SYMBOL);
+    1422	    if(CAAR(frame) == symbol)
+    1423	      return CAR(frame);
+    1424	    frame = CDR(frame);
+    1425	  }
+    (gdb) print CAAR(frame)->type.type
+    $3 = 13
 
 The number 13 is the value :c:data:`TYPE_PAD`. So instead of the
-expected pair, :c:data:`frame` points to a :term:`padding object`.
+expected symbol, ``CAAR(frame)`` points to a :term:`padding object`.
 
-You might guess at this point that the frame had not been fixed, and
+You might guess at this point that the symbol had not been fixed, and
 since you know that the frame is referenced by the :c:member:`car` of
 the first pair in the environment, that's the suspect reference. But
 in a more complex situation this might not yet be clear. In such a
@@ -375,11 +376,11 @@ the wrong size:
 .. code-block:: c
     :emphasize-lines: 5
 
-    static obj_t make_string(size_t length, char *string)
+    static obj_t make_string(size_t length, const char *string)
     {
       obj_t obj;
       mps_addr_t addr;
-      size_t size = ALIGN_OBJ(offsetof(string_s, string) + length/* oops, forgot: +1 */);
+      size_t size = ALIGN_OBJ(offsetof(string_s, string) + length /* oops, forgot +1 */);
       do {
         mps_res_t res = mps_reserve(&addr, obj_ap, size);
         if (res != MPS_RES_OK) error("out of memory in make_string");
@@ -403,106 +404,126 @@ Here's a test case that exercises this bug:
 And here's how it shows up in the debugger:
 
 .. code-block:: none
-    :emphasize-lines: 47
+    :emphasize-lines: 53
 
-    $ gdb ./scheme
-    GNU gdb 6.3.50-20050815 (Apple version gdb-1820) (Sat Jun 16 02:40:11 UTC 2012)
-    [...]
+    $ gdb -q ./scheme
+    Reading symbols from ./scheme...done.
     (gdb) run < test.scm
-    Starting program: example/scheme/scheme < test.scm
-    Reading symbols for shared libraries +............................. done
+    Starting program: /home/grees/github.com/mps/example/scheme/scheme < test.scm
+    [Thread debugging using libthread_db enabled]
+    Using host libthread_db library "/lib/x86_64-linux-gnu/libthread_db.so.1".
     MPS Toy Scheme Example
-    [...]
-    9960, 0> church
-    Assertion failed: (0), function obj_skip, file scheme.c, line 2940.
-    10816, 0> 
+    The prompt shows total allocated bytes and number of collections.
+    Try (vector-length (make-vector 100000 1)) to see the MPS in action.
+    You can force a complete garbage collection with (gc).
+    If you recurse too much the interpreter may crash from using too much C stack.
+    13248, 0> church
+    14104, 0> scheme: scheme.c:4067: obj_skip: Assertion `0' failed.
+
     Program received signal SIGABRT, Aborted.
-    0x00007fff91aeed46 in __kill ()
+    __GI_raise (sig=sig@entry=6) at ../sysdeps/unix/sysv/linux/raise.c:51
+    51	../sysdeps/unix/sysv/linux/raise.c: No such file or directory.
     (gdb) backtrace
-    #0  0x00007fff91aeed46 in __kill ()
-    #1  0x00007fff90509df0 in abort ()
-    #2  0x00007fff9050ae2a in __assert_rtn ()
-    #3  0x00000001000014e3 in obj_skip (base=0x1003f9b88) at scheme.c:2940
-    #4  0x0000000100068050 in amcScanNailedOnce (totalReturn=0x7fff5fbfef2c, moreReturn=0x7fff5fbfef28, ss=0x7fff5fbff0a0, pool=0x1003fe278, seg=0x1003fe928, amc=0x1003fe278) at poolamc.c:1485
-    #5  0x0000000100067ca1 in amcScanNailed (totalReturn=0x7fff5fbff174, ss=0x7fff5fbff0a0, pool=0x1003fe278, seg=0x1003fe928, amc=0x1003fe278) at poolamc.c:1522
-    #6  0x000000010006631f in AMCScan (totalReturn=0x7fff5fbff174, ss=0x7fff5fbff0a0, pool=0x1003fe278, seg=0x1003fe928) at poolamc.c:1595
-    #7  0x000000010002686d in PoolScan (totalReturn=0x7fff5fbff174, ss=0x7fff5fbff0a0, pool=0x1003fe278, seg=0x1003fe928) at pool.c:405
-    #8  0x0000000100074106 in traceScanSegRes (ts=1, rank=1, arena=0x10012a000, seg=0x1003fe928) at trace.c:1162
-    #9  0x000000010002b399 in traceScanSeg (ts=1, rank=1, arena=0x10012a000, seg=0x1003fe928) at trace.c:1222
-    #10 0x000000010002d020 in TraceQuantum (trace=0x10012a5a0) at trace.c:1833
-    #11 0x000000010001f2d2 in TracePoll (globals=0x10012a000) at trace.c:1981
-    #12 0x000000010000d75f in ArenaPoll (globals=0x10012a000) at global.c:684
-    #13 0x000000010000ea40 in mps_ap_fill (p_o=0x7fff5fbff3e0, mps_ap=0x1003fe820, size=208) at mpsi.c:961
-    #14 0x000000010000447d in make_string (length=190, string=0x0) at scheme.c:468
-    #15 0x0000000100008ca2 in entry_string_append (env=0x1003cbe38, op_env=0x1003cbe50, operator=0x1003fad48, operands=0x1003f9af8) at scheme.c:2562
-    #16 0x0000000100002fe4 in eval (env=0x1003cbe38, op_env=0x1003cbe50, exp=0x1003f9ae0) at scheme.c:1159
-    #17 0x0000000100005ff5 in entry_interpret (env=0x1003cb958, op_env=0x1003cb970, operator=0x1003f99d8, operands=0x1003f9948) at scheme.c:1340
-    #18 0x0000000100002fe4 in eval (env=0x1003cb958, op_env=0x1003cb970, exp=0x1003f9878) at scheme.c:1159
-    #19 0x000000010000206b in start (p=0x0, s=0) at scheme.c:3213
-    #20 0x000000010001287d in ProtTramp (resultReturn=0x7fff5fbff7a0, f=0x100001b80 <start>, p=0x0, s=0) at protix.c:132
-    #21 0x0000000100001947 in main (argc=1, argv=0x7fff5fbff808) at scheme.c:3314
-    (gdb) frame 3
-    #3  0x00000001000014e3 in obj_skip (base=0x1003f9b88) at scheme.c:2940
-    2940            assert(0);
+    #0  __GI_raise (sig=sig@entry=6) at ../sysdeps/unix/sysv/linux/raise.c:51
+    #1  0x00007ffff78058b1 in __GI_abort () at abort.c:79
+    #2  0x00007ffff77f542a in __assert_fail_base (fmt=0x7ffff797ca38 "%s%s%s:%u: %s%sAssertion `%s' failed.\n%n", assertion=assertion@entry=0x555555603e0f "0", file=file@entry=0x555555603c32 "scheme.c", line=line@entry=4067, function=function@entry=0x555555605568 <__PRETTY_FUNCTION__.4815> "obj_skip") at assert.c:92
+    #3  0x00007ffff77f54a2 in __GI___assert_fail (assertion=0x555555603e0f "0", file=0x555555603c32 "scheme.c", line=4067, function=0x555555605568 <__PRETTY_FUNCTION__.4815> "obj_skip") at assert.c:101
+    #4  0x000055555556434b in obj_skip (base=0x7ffff58af898) at scheme.c:4067
+    #5  0x00005555555e15bf in amcSegScanNailedRange (totalReturn=0x7fffffffd4a0, moreReturn=0x7fffffffd4a4, ss=0x7fffffffd5f0, amc=0x7ffff57f73f8, board=0x7ffff57f8a40, base=0x7ffff58ae000, limit=0x7ffff58afff0) at ../../code/poolamc.c:1278
+    #6  0x00005555555e177b in amcSegScanNailedOnce (totalReturn=0x7fffffffd4a0, moreReturn=0x7fffffffd4a4, ss=0x7fffffffd5f0, seg=0x7ffff57f89a8, amc=0x7ffff57f73f8) at ../../code/poolamc.c:1325
+    #7  0x00005555555e187c in amcSegScanNailed (totalReturn=0x7fffffffd5d0, ss=0x7fffffffd5f0, pool=0x7ffff57f73f8, seg=0x7ffff57f89a8, amc=0x7ffff57f73f8) at ../../code/poolamc.c:1355
+    #8  0x00005555555e1bd3 in amcSegScan (totalReturn=0x7fffffffd5d0, seg=0x7ffff57f89a8, ss=0x7fffffffd5f0) at ../../code/poolamc.c:1413
+    #9  0x0000555555599188 in SegScan (totalReturn=0x7fffffffd5d0, seg=0x7ffff57f89a8, ss=0x7fffffffd5f0) at ../../code/seg.c:778
+    #10 0x000055555558c926 in traceScanSegRes (ts=1, rank=1, arena=0x7ffff7ff7000, seg=0x7ffff57f89a8) at ../../code/trace.c:1148
+    #11 0x000055555558cb2d in traceScanSeg (ts=1, rank=1, arena=0x7ffff7ff7000, seg=0x7ffff57f89a8) at ../../code/trace.c:1223
+    #12 0x000055555558e24d in TraceAdvance (trace=0x7ffff7ff7ac0) at ../../code/trace.c:1664
+    #13 0x000055555558e792 in TracePoll (workReturn=0x7fffffffd7b0, collectWorldReturn=0x7fffffffd78c, globals=0x7ffff7ff7008, collectWorldAllowed=1) at ../../code/trace.c:1784
+    #14 0x000055555557c990 in ArenaPoll (globals=0x7ffff7ff7008) at ../../code/global.c:760
+    #15 0x00005555555690ed in mps_ap_fill (p_o=0x7fffffffd940, mps_ap=0x7ffff57f7928, size=24) at ../../code/mpsi.c:1111
+    #16 0x0000555555559c93 in make_pair (car=0x7ffff58afbf0, cdr=0x7ffff5880000) at scheme.c:457
+    #17 0x000055555555d605 in eval_list (env=0x7ffff58afed0, op_env=0x7ffff58afee8, list=0x7ffff5883828, message=0x5555556041f8 "eval: badly formed argument list") at scheme.c:1564
+    #18 0x000055555555d94b in eval_args_rest (name=0x555555604e02 "string-append", env=0x7ffff58afed0, op_env=0x7ffff58afee8, operands=0x7ffff5883828, restp=0x7fffffffdb00, n=0) at scheme.c:1637
+    #19 0x0000555555562870 in entry_string_append (env=0x7ffff58afed0, op_env=0x7ffff58afee8, operator=0x7ffff5882340, operands=0x7ffff5883828) at scheme.c:3396
+    #20 0x000055555555d420 in eval (env=0x7ffff58afed0, op_env=0x7ffff58afee8, exp=0x7ffff5883810) at scheme.c:1511
+    #21 0x000055555555dbc8 in entry_interpret (env=0x7ffff58af9e0, op_env=0x7ffff58af9f8, operator=0x7ffff5883700, operands=0x7ffff5883670) at scheme.c:1713
+    #22 0x000055555555d420 in eval (env=0x7ffff58af9e0, op_env=0x7ffff58af9f8, exp=0x7ffff5883598) at scheme.c:1511
+    #23 0x0000555555564fab in start (argc=0, argv=0x7fffffffe0d0) at scheme.c:4341
+    #24 0x0000555555565799 in main (argc=0, argv=0x7fffffffe0d0) at scheme.c:4489
+    (gdb) frame 4
+    #4  0x000055555556434b in obj_skip (base=0x7ffff58af898) at scheme.c:4067
+    4067	    assert(0);
     (gdb) list
-    2935            break;
-    2936          case TYPE_PAD1:
-    2937            base = (char *)base + ALIGN_OBJ(sizeof(pad1_s));
-    2938            break;
-    2939          default:
-    2940            assert(0);
-    2941            fprintf(stderr, "Unexpected object on the heap\n");
-    2942            abort();
-    2943            return NULL;
-    2944          }
+    4062	    break;
+    4063	  case TYPE_PAD1:
+    4064	    base = (char *)base + ALIGN_WORD(sizeof(pad1_s));
+    4065	    break;
+    4066	  default:
+    4067	    assert(0);
+    4068	    fflush(stdout);
+    4069	    fprintf(stderr, "Unexpected object on the heap\n");
+    4070	    abort();
+    4071	  }
 
 The object being skipped is corrupt::
 
     (gdb) print obj->type.type
-    $1 = 4168560
+    $1 = -175623000
 
 What happened to it? It's often helpful in these situations to have a
 look at nearby memory. ::
 
-    (gdb) x/20g obj
-    0x1003f9b88:        0x00000001003f9b70      0x00000001003fb000
-    0x1003f9b98:        0x0000000000000000      0x00000001003f9c90
-    0x1003f9ba8:        0x00000001003fb130      0x0000000000000000
-    0x1003f9bb8:        0x00000001003fb000      0x00000001003fb148
-    0x1003f9bc8:        0x0000000000000000      0x00000001003f9730
-    0x1003f9bd8:        0x00000001003f9a58      0x0000000000000000
-    0x1003f9be8:        0x00000001003f9bc8      0x00000001003fb000
-    0x1003f9bf8:        0x0000000000000000      0x00000001003fb0a0
-    0x1003f9c08:        0x00000001003f9b40      0x0000000000000004
-    0x1003f9c18:        0x000000010007b14a      0x0000000100005e30
+    (gdb) x/20gx obj
+    0x7ffff58af898:	0x00007ffff58834a8	0x00007ffff58af7c8
+    0x7ffff58af8a8:	0x0000000000000000	0x00007ffff58af890
+    0x7ffff58af8b8:	0x00007ffff58af660	0x0000000000000000
+    0x7ffff58af8c8:	0x00007ffff58836e8	0x00007ffff5880000
+    0x7ffff58af8d8:	0x0000000000000000	0x00007ffff58af5d0
+    0x7ffff58af8e8:	0x00007ffff58af8c0	0x0000000000000000
+    0x7ffff58af8f8:	0x00007ffff58af5b8	0x00007ffff58af8d8
+    0x7ffff58af908:	0x0000000000000000	0x00007ffff5880090
+    0x7ffff58af918:	0x00007ffff58af8f0	0x0000000000000000
+    0x7ffff58af928:	0x00007ffff58834f0	0x00007ffff5880000
 
-You can see that this is a block containing mostly pairs (which have
-tag 0 and consist of three words), though you can see an operator
-(with tag 4) near the bottom. But what's that at the start of the
-block, where :c:data:`obj`\'s tag should be? It looks like a pointer. So
-what's in the memory just below :c:data:`obj`? Let's look at the previous
-few words::
+You can see that this is a region of memory containing pairs, which
+have type :c:data:`TYPE_PAIR` = 0 and consist of three words. But
+what's that at the start of the region, where :c:data:`obj`\'s tag
+should be? It looks like a pointer. So what's in the memory just below
+:c:data:`obj`? Let's look at the previous region of memory::
 
-    (gdb) x/10g (mps_word_t*)obj-8
-    0x1003f9b48:        0x00000001003f9ae0      0x00000001003fb000
-    0x1003f9b58:        0x0000000000000000      0x00000001003f9a80
-    0x1003f9b68:        0x00000001003f9b80      0x0000000000000005
-    0x1003f9b78:        0x0000000000000000      0x0000000000000000
-    0x1003f9b88:        0x00000001003f9b70      0x00000001003fb000
+    (gdb) x/30gx (mps_word_t*)obj-28
+    0x7ffff58af7b8:	0x00007ffff5883840	0x00007ffff5880000
+    0x7ffff58af7c8:	0x0000000000000005	0x00000000000000b8
+    0x7ffff58af7d8:	0x7878787878787878	0x7878787878787878
+    0x7ffff58af7e8:	0x7878787878787878	0x7878787878787878
+    0x7ffff58af7f8:	0x7878787878787878	0x7878787878787878
+    0x7ffff58af808:	0x7878787878787878	0x7878787878787878
+    0x7ffff58af818:	0x7878787878787878	0x7878787878787878
+    0x7ffff58af828:	0x7878787878787878	0x7878787878787878
+    0x7ffff58af838:	0x7878787878787878	0x7878787878787878
+    0x7ffff58af848:	0x7878787878787878	0x7878787878787878
+    0x7ffff58af858:	0x7878787878787878	0x7878787878787878
+    0x7ffff58af868:	0x7878787878787878	0x7878787878787878
+    0x7ffff58af878:	0x7878787878787878	0x7878787878787878
+    0x7ffff58af888:	0x7878787878787878	0x0000000000000000
+    0x7ffff58af898:	0x00007ffff58834a8	0x00007ffff58af7c8
 
-Yes: there's a pair (with tag 0) at ``0x1003f9b80``. So it looks
-as though the previous object was allocated with one size, but skipped
-with a different size. The previous object being the string (with tag
-5) at ``0x1003f9b70`` which has length 0 and so is three words long as
-far as :c:func:`obj_skip` is concerned::
+In this region we can see a string starting at address
+``0x7ffff58af7c8``. Its type is :c:data:`TYPE_STRING` = 5, its length
+is 0xb8 = 184, and its contents is 184 repetitions of the byte 0x78
+(ASCII for "x") resulting from the repeated ``(string-append s "x")``
+in the test code. The string is followed by a pair (with type 0) at
+the address ``0x7ffff58af890``, which is one word before
+:c:data:`obj`. So it looks as though :c:data:`obj` should be pointing
+at the pair, but its value is one word too low.
 
-    (gdb) print obj_skip(0x1003f9b70)
-    $2 = (mps_addr_t) 0x1003f9b88
+The value in :c:data:`obj` comes from skipping the string object::
 
-but the next object (the pair) was clearly allocated at
-``0x1003f9b80`` (overwriting the last word of the string), so the
-string must have been allocated with a size of only two words. This
-should be enough evidence to track down the cause.
+    (gdb) print obj_skip(0x7ffff58af7c8)
+    $3 = (void *) 0x7ffff58af898
+
+So either :c:func:`obj_skip` has skipped one word too far, or the
+string object is one word too short. This should be enough evidence to
+track down the cause.
 
 
 What next?


### PR DESCRIPTION
Since these examples were written, the Scheme source code has changed, and MPS backtraces have changed.

Fixes [job004107](https://www.ravenbrook.com/project/mps/issue/job004107/) (Debugging chapter is out of date)