### PR TITLE
Remove mps_alloc_v, deprecated since release 1.112.0.

### DIFF
--- a/code/mps.h
+++ b/code/mps.h
@@ -516,7 +516,6 @@ extern void mps_chain_destroy(mps_chain_t);
 /* Manual Allocation */
 
 extern mps_res_t mps_alloc(mps_addr_t *, mps_pool_t, size_t);
-extern mps_res_t mps_alloc_v(mps_addr_t *, mps_pool_t, size_t, va_list);
 extern void mps_free(mps_pool_t, mps_addr_t, size_t);
 
 

--- a/code/mpsi.c
+++ b/code/mpsi.c
@@ -785,7 +785,6 @@ mps_res_t mps_alloc(mps_addr_t *p_o, mps_pool_t pool, size_t size)
     AVER_CRITICAL(size > 0);
     /* Note: class may allow unaligned size, see */
     /* <design/pool#.method.alloc.size.align>. */
-    /* Rest ignored, see .varargs. */
 
     res = PoolAlloc(&p, pool, size);
 
@@ -796,19 +795,6 @@ mps_res_t mps_alloc(mps_addr_t *p_o, mps_pool_t pool, size_t size)
     return (mps_res_t)res;
   *p_o = (mps_addr_t)p;
   return MPS_RES_OK;
-}
-
-
-/* mps_alloc_v -- allocate in pool with varargs.  Deprecated in 1.112. */
-
-mps_res_t mps_alloc_v(mps_addr_t *p_o, mps_pool_t mps_pool, size_t size,
-                      va_list args)
-{
-  mps_res_t res;
-
-  UNUSED(args); /* See .varargs. */
-  res = mps_alloc(p_o, mps_pool, size);
-  return res;
 }
 
 

--- a/code/mpsicv.c
+++ b/code/mpsicv.c
@@ -173,21 +173,6 @@ static mps_addr_t make_no_inline(void)
 }
 
 
-/* alloc_v_test -- test mps_alloc_v */
-
-static void alloc_v_test(mps_pool_t pool, ...)
-{
-  void *p;
-  size_t size = 32;
-  va_list args;
-
-  va_start(args, pool);
-  die(mps_alloc_v(&p, pool, size, args), "alloc_v");
-  va_end(args);
-  mps_free(pool, p, size);
-}
-
-
 static void pool_create_v_test(mps_arena_t arena, ...)
 {
   va_list args;
@@ -542,7 +527,6 @@ static void test(mps_arena_t arena)
   mps_arena_release(arena);
 
   mps_free(mv, alloced_obj, 32);
-  alloc_v_test(mv);
 
   mps_arena_park(arena);
   mps_pool_destroy(mv);


### PR DESCRIPTION
This function was never documented (and never did anything useful), so I haven't put anything in the release notes.