### PR TITLE
Ensure that the MPS builds with "clang -Werror -Wcomma -std=c89"

### DIFF
--- a/code/amcsshe.c
+++ b/code/amcsshe.c
@@ -192,7 +192,7 @@ static void *test(mps_arena_t arena, mps_pool_class_t pool_class,
       if (exactRoots[r] != objNULL) {
         char *p = (char*)exactRoots[r];
 
-        for(i = 0; i < bogusRootsCOUNT; ++i, ++p)
+        for(i = 0; i < bogusRootsCOUNT; (void)(++i), ++p)
           bogusRoots[i] = (mps_addr_t)p;
       }
     }

--- a/code/amcsshe.c
+++ b/code/amcsshe.c
@@ -192,8 +192,8 @@ static void *test(mps_arena_t arena, mps_pool_class_t pool_class,
       if (exactRoots[r] != objNULL) {
         char *p = (char*)exactRoots[r];
 
-        for(i = 0; i < bogusRootsCOUNT; (void)(++i), ++p)
-          bogusRoots[i] = (mps_addr_t)p;
+        for(i = 0; i < bogusRootsCOUNT; ++i)
+          bogusRoots[i] = (mps_addr_t)(p + i);
       }
     }
 

--- a/code/bt.c
+++ b/code/bt.c
@@ -1005,9 +1005,9 @@ void BTCopyOffsetRange(BT fromBT, BT toBT,
   AVER(toBase < toLimit);
   AVER((fromLimit - fromBase) == (toLimit - toBase));
 
-  for ((void)(fromBit = fromBase), toBit = toBase;
+  for (ITER_PARALLEL(fromBit = fromBase, toBit = toBase);
        fromBit < fromLimit;
-       (void)(++fromBit), ++toBit)
+       ITER_PARALLEL(++fromBit, ++toBit))
   {
     if (BTGet(fromBT, fromBit))
       BTSet(toBT, toBit);

--- a/code/bt.c
+++ b/code/bt.c
@@ -1005,9 +1005,10 @@ void BTCopyOffsetRange(BT fromBT, BT toBT,
   AVER(toBase < toLimit);
   AVER((fromLimit - fromBase) == (toLimit - toBase));
 
-  for (fromBit = fromBase, toBit = toBase;
+  for ((void)(fromBit = fromBase), toBit = toBase;
        fromBit < fromLimit;
-       ++fromBit, ++toBit) {
+       (void)(++fromBit), ++toBit)
+  {
     if (BTGet(fromBT, fromBit))
       BTSet(toBT, toBit);
     else

--- a/code/ll.gmk
+++ b/code/ll.gmk
@@ -18,6 +18,7 @@ CFLAGSCOMPILER := \
 	-Waggregate-return \
 	-Wall \
 	-Wcast-qual \
+	-Wcomma \
 	-Wconversion \
 	-Wduplicate-enum \
 	-Werror \

--- a/code/misc.h
+++ b/code/misc.h
@@ -246,7 +246,8 @@ typedef const struct SrcIdStruct {
 
 
 /* Iterate over two expressions in parallel, avoiding warnings from
- * clang -Wcomma -std=c89.
+ * clang -Wcomma -std=c89, while clearly expressing intention.  See
+ * <https://github.com/Ravenbrook/mps/pull/48#issuecomment-757458796>.
  */
 
 #define ITER_PARALLEL(expr1, expr2) ((void)(expr1), expr2)

--- a/code/misc.h
+++ b/code/misc.h
@@ -245,6 +245,13 @@ typedef const struct SrcIdStruct {
 #define ERRNO_RESTORE END; errno = _saved_errno; END
 
 
+/* Iterate over two expressions in parallel, avoiding warnings from
+ * clang -Wcomma -std=c89.
+ */
+
+#define ITER_PARALLEL(expr1, expr2) ((void)(expr1), expr2)
+
+
 #endif /* misc_h */
 
 

--- a/code/mpm.h
+++ b/code/mpm.h
@@ -341,11 +341,15 @@ extern const char *MessageNoGCStartWhy(Message message);
 #define TraceSetComp(ts)            BS_COMP(ts)
 
 #define TRACE_SET_ITER(ti, trace, ts, arena) \
-  for ((void)(ti = 0), trace = ArenaTrace(arena, ti); ti < TraceLIMIT; \
-       (void)(++ti), trace = ArenaTrace(arena, ti)) BEGIN \
-    if (TraceSetIsMember(ts, trace)) {
+  BEGIN \
+    for (ti = 0; ti < TraceLIMIT; ++ti) { \
+      trace = ArenaTrace(arena, ti); \
+      if (TraceSetIsMember(ts, trace)) {
 
-#define TRACE_SET_ITER_END(ti, trace, ts, arena) } END
+#define TRACE_SET_ITER_END(ti, trace, ts, arena) \
+      } \
+    } \
+  END
 
 
 extern void ScanStateInit(ScanState ss, TraceSet ts, Arena arena,

--- a/code/mpm.h
+++ b/code/mpm.h
@@ -341,8 +341,8 @@ extern const char *MessageNoGCStartWhy(Message message);
 #define TraceSetComp(ts)            BS_COMP(ts)
 
 #define TRACE_SET_ITER(ti, trace, ts, arena) \
-  for(ti = 0, trace = ArenaTrace(arena, ti); ti < TraceLIMIT; \
-      ++ti, trace = ArenaTrace(arena, ti)) BEGIN \
+  for ((void)(ti = 0), trace = ArenaTrace(arena, ti); ti < TraceLIMIT; \
+       (void)(++ti), trace = ArenaTrace(arena, ti)) BEGIN \
     if (TraceSetIsMember(ts, trace)) {
 
 #define TRACE_SET_ITER_END(ti, trace, ts, arena) } END

--- a/code/nailboard.c
+++ b/code/nailboard.c
@@ -370,7 +370,9 @@ Bool NailboardIsResRange(Nailboard board, Addr base, Addr limit)
                 || BTGet(board->level[i], ilimit - 1));
 
   /* Left splinter */
-  for ((void)(j = i), jbase = ibase;;) {
+  j = i;
+  jbase = ibase;
+  for (;;) {
     leftLimit = nailboardAddr(board, j, jbase + 1);
     AVER_CRITICAL(base < leftLimit);
     AVER_CRITICAL(leftLimit < limit);
@@ -385,7 +387,9 @@ Bool NailboardIsResRange(Nailboard board, Addr base, Addr limit)
   }
 
   /* Right splinter */
-  for ((void)(j = i), jlimit = ilimit;;) {
+  j = i;
+  jlimit = ilimit;
+  for (;;) {
     rightBase = nailboardAddr(board, j, jlimit - 1);
     AVER_CRITICAL(base < rightBase);
     AVER_CRITICAL(rightBase < limit);

--- a/code/nailboard.c
+++ b/code/nailboard.c
@@ -370,7 +370,7 @@ Bool NailboardIsResRange(Nailboard board, Addr base, Addr limit)
                 || BTGet(board->level[i], ilimit - 1));
 
   /* Left splinter */
-  for (j = i, jbase = ibase;;) {
+  for ((void)(j = i), jbase = ibase;;) {
     leftLimit = nailboardAddr(board, j, jbase + 1);
     AVER_CRITICAL(base < leftLimit);
     AVER_CRITICAL(leftLimit < limit);
@@ -385,7 +385,7 @@ Bool NailboardIsResRange(Nailboard board, Addr base, Addr limit)
   }
 
   /* Right splinter */
-  for (j = i, jlimit = ilimit;;) {
+  for ((void)(j = i), jlimit = ilimit;;) {
     rightBase = nailboardAddr(board, j, jlimit - 1);
     AVER_CRITICAL(base < rightBase);
     AVER_CRITICAL(rightBase < limit);

--- a/code/poolmrg.c
+++ b/code/poolmrg.c
@@ -768,20 +768,17 @@ Res MRGDeregister(Pool pool, Ref obj)
     MRGRefSeg refSeg = RING_ELT(MRGRefSeg, mrgRing, node);
     MRGLinkSeg linkSeg;
     Count i;
-    Link link;
-    RefPart refPart;
+    Link linkBase;
+    RefPart refPartBase;
 
     AVERT(MRGRefSeg, refSeg);
     linkSeg = refSeg->linkSeg;
+    linkBase = (Link)SegBase(MustBeA(Seg, linkSeg));
+    refPartBase = (RefPart)SegBase(MustBeA(Seg, refSeg));
     /* map over each guardian in the segment */
-    for ((void)(i = 0),
-         (void)(link = (Link)SegBase(MustBeA(Seg, linkSeg))),
-         refPart = (RefPart)SegBase(MustBeA(Seg, refSeg));
-         i < nGuardians;
-         (void)(++i),
-         (void)(++link),
-         ++refPart)
-    {
+    for (i = 0; i < nGuardians; ++i) {
+      Link link = linkBase + i;
+      RefPart refPart = refPartBase + i;
       /* check if it's allocated and points to obj */
       if (link->state == MRGGuardianPREFINAL
           && MRGRefPartRef(arena, refPart) == obj) {

--- a/code/poolmrg.c
+++ b/code/poolmrg.c
@@ -774,10 +774,14 @@ Res MRGDeregister(Pool pool, Ref obj)
     AVERT(MRGRefSeg, refSeg);
     linkSeg = refSeg->linkSeg;
     /* map over each guardian in the segment */
-    for(i = 0, link = (Link)SegBase(MustBeA(Seg, linkSeg)),
-          refPart = (RefPart)SegBase(MustBeA(Seg, refSeg));
-        i < nGuardians;
-        ++i, ++link, ++refPart) {
+    for ((void)(i = 0),
+         (void)(link = (Link)SegBase(MustBeA(Seg, linkSeg))),
+         refPart = (RefPart)SegBase(MustBeA(Seg, refSeg));
+         i < nGuardians;
+         (void)(++i),
+         (void)(++link),
+         ++refPart)
+    {
       /* check if it's allocated and points to obj */
       if (link->state == MRGGuardianPREFINAL
           && MRGRefPartRef(arena, refPart) == obj) {

--- a/code/ring.h
+++ b/code/ring.h
@@ -106,9 +106,9 @@ extern Ring (RingPrev)(Ring ring);
 
 /* .ring.for: <design/ring#.for> */
 #define RING_FOR(node, ring, next) \
-  for((void)(node = RingNext(ring)), next = RingNext(node); \
-      node != (ring); \
-      (void)(node = (next)), next = RingNext(node))
+  for (ITER_PARALLEL(node = RingNext(ring), next = RingNext(node)); \
+       node != (ring); \
+       ITER_PARALLEL(node = (next), next = RingNext(node)))
 
 
 #endif /* ring_h */

--- a/code/ring.h
+++ b/code/ring.h
@@ -106,9 +106,9 @@ extern Ring (RingPrev)(Ring ring);
 
 /* .ring.for: <design/ring#.for> */
 #define RING_FOR(node, ring, next) \
-  for(node = RingNext(ring), next = RingNext(node); \
+  for((void)(node = RingNext(ring)), next = RingNext(node); \
       node != (ring); \
-      node = (next), next = RingNext(node))
+      (void)(node = (next)), next = RingNext(node))
 
 
 #endif /* ring_h */

--- a/code/sac.c
+++ b/code/sac.c
@@ -23,7 +23,8 @@ static Bool sacFreeListBlockCheck(SACFreeListBlock fb)
   /* nothing to check about size */
   CHECKL(fb->_count <= fb->_count_max);
   /* check the freelist has the right number of blocks */
-  for ((void)(j = 0), cb = fb->_blocks; j < fb->_count; ++j) {
+  cb = fb->_blocks;
+  for (j = 0; j < fb->_count; ++j) {
     CHECKL(cb != NULL);
     /* @@@@ ignoring shields for now */
     cb = *ADDR_PTR(Addr, cb);
@@ -31,6 +32,25 @@ static Bool sacFreeListBlockCheck(SACFreeListBlock fb)
   CHECKL(cb == NULL);
   return TRUE;
 }
+
+
+/* SAC_LARGE_ITER -- iterate over the large classes (the ones above
+ * middle), setting the variable j to the index of the class, and i to
+ * the index of the corresponding free list.
+ */
+#define SAC_LARGE_ITER(middle, classes, i, j) \
+  for (ITER_PARALLEL(j = (middle) + 1, i = 0); \
+       j < (classes); \
+       ITER_PARALLEL(++j, i += 2))
+
+
+/* SAC_SMALL_ITER -- iterate over the small classes (middle and
+ * below), setting the variable j to the index of the class, and i to
+ * the index of the corresponding free list.
+ */
+#define SAC_SMALL_ITER(middle, i, j) \
+  for (ITER_PARALLEL(j = (middle), i = 1); j > 0; ITER_PARALLEL(--j, i += 2))
+
 
 ATTRIBUTE_UNUSED
 static Bool SACCheck(SAC sac)
@@ -49,7 +69,7 @@ static Bool SACCheck(SAC sac)
   CHECKL(esac->_middle > 0);
   /* check classes above middle */
   prevSize = esac->_middle;
-  for ((void)(j = sac->middleIndex + 1), i = 0; j < sac->classesCount; (void)(++j), i += 2) {
+  SAC_LARGE_ITER(sac->middleIndex, sac->classesCount, i, j) {
     CHECKL(prevSize < esac->_freelists[i]._size);
     b = sacFreeListBlockCheck(&(esac->_freelists[i]));
     if (!b)
@@ -67,7 +87,7 @@ static Bool SACCheck(SAC sac)
   CHECKL(esac->_freelists[i]._blocks == NULL);
   /* check classes below middle */
   prevSize = esac->_middle;
-  for ((void)(j = sac->middleIndex), i = 1; j > 0; (void)(--j), i += 2) {
+  SAC_SMALL_ITER(sac->middleIndex, i, j) {
     CHECKL(prevSize > esac->_freelists[i]._size);
     b = sacFreeListBlockCheck(&(esac->_freelists[i]));
     if (!b)
@@ -157,7 +177,7 @@ Res SACCreate(SAC *sacReturn, Pool pool, Count classesCount,
   /* Move classes in place */
   /* It's important this matches SACFind. */
   esac = ExternalSACOfSAC(sac);
-  for ((void)(j = middleIndex + 1), i = 0; j < classesCount; (void)(++j), i += 2) {
+  SAC_LARGE_ITER(middleIndex, classesCount, i, j) {
     esac->_freelists[i]._size = classes[j].mps_block_size;
     esac->_freelists[i]._count = 0;
     esac->_freelists[i]._count_max = classes[j].mps_cached_count;
@@ -167,7 +187,7 @@ Res SACCreate(SAC *sacReturn, Pool pool, Count classesCount,
   esac->_freelists[i]._count = 0;
   esac->_freelists[i]._count_max = 0;
   esac->_freelists[i]._blocks = NULL;
-  for ((void)(j = middleIndex), i = 1; j > 0; (void)(--j), i += 2) {
+  SAC_SMALL_ITER(middleIndex, i, j) {
     esac->_freelists[i]._size = classes[j-1].mps_block_size;
     esac->_freelists[i]._count = 0;
     esac->_freelists[i]._count_max = classes[j].mps_cached_count;
@@ -268,8 +288,8 @@ Res SACFill(Addr *p_o, SAC sac, Size size)
   if (blockSize == SizeMAX)
     /* .align: align 'cause some classes don't accept unaligned. */
     blockSize = SizeAlignUp(size, PoolAlignment(sac->pool));
-  for ((void)(j = 0), fl = esac->_freelists[i]._blocks;
-       j <= blockCount; ++j) {
+  fl = esac->_freelists[i]._blocks;
+  for (j = 0; j <= blockCount; ++j) {
     res = PoolAlloc(&p, sac->pool, blockSize);
     if (res != ResOK)
       break;
@@ -304,8 +324,8 @@ static void sacClassFlush(SAC sac, Index i, Size blockSize,
   mps_sac_t esac;
 
   esac = ExternalSACOfSAC(sac);
-  for ((void)(j = 0), fl = esac->_freelists[i]._blocks;
-       j < blockCount; ++j) {
+  fl = esac->_freelists[i]._blocks;
+  for (j = 0; j < blockCount; ++j) {
     /* @@@@ ignoring shields for now */
     cb = fl; fl = *ADDR_PTR(Addr, cb);
     PoolFree(sac->pool, cb, blockSize);
@@ -369,15 +389,14 @@ void SACFlush(SAC sac)
   AVERT(SAC, sac);
 
   esac = ExternalSACOfSAC(sac);
-  for ((void)(j = sac->middleIndex + 1), i = 0;
-       j < sac->classesCount; (void)(++j), i += 2) {
+  SAC_LARGE_ITER(sac->middleIndex, sac->classesCount, i, j) {
     sacClassFlush(sac, i, esac->_freelists[i]._size,
                   esac->_freelists[i]._count);
     AVER(esac->_freelists[i]._blocks == NULL);
   }
   /* no need to flush overlarge, there's nothing there */
   prevSize = esac->_middle;
-  for ((void)(j = sac->middleIndex), i = 1; j > 0; (void)(--j), i += 2) {
+  SAC_SMALL_ITER(sac->middleIndex, i, j) {
     sacClassFlush(sac, i, prevSize, esac->_freelists[i]._count);
     AVER(esac->_freelists[i]._blocks == NULL);
     prevSize = esac->_freelists[i]._size;

--- a/code/sac.c
+++ b/code/sac.c
@@ -23,7 +23,7 @@ static Bool sacFreeListBlockCheck(SACFreeListBlock fb)
   /* nothing to check about size */
   CHECKL(fb->_count <= fb->_count_max);
   /* check the freelist has the right number of blocks */
-  for (j = 0, cb = fb->_blocks; j < fb->_count; ++j) {
+  for ((void)(j = 0), cb = fb->_blocks; j < fb->_count; ++j) {
     CHECKL(cb != NULL);
     /* @@@@ ignoring shields for now */
     cb = *ADDR_PTR(Addr, cb);
@@ -49,7 +49,7 @@ static Bool SACCheck(SAC sac)
   CHECKL(esac->_middle > 0);
   /* check classes above middle */
   prevSize = esac->_middle;
-  for (j = sac->middleIndex + 1, i = 0; j < sac->classesCount; ++j, i += 2) {
+  for ((void)(j = sac->middleIndex + 1), i = 0; j < sac->classesCount; (void)(++j), i += 2) {
     CHECKL(prevSize < esac->_freelists[i]._size);
     b = sacFreeListBlockCheck(&(esac->_freelists[i]));
     if (!b)
@@ -67,7 +67,7 @@ static Bool SACCheck(SAC sac)
   CHECKL(esac->_freelists[i]._blocks == NULL);
   /* check classes below middle */
   prevSize = esac->_middle;
-  for (j = sac->middleIndex, i = 1; j > 0; --j, i += 2) {
+  for ((void)(j = sac->middleIndex), i = 1; j > 0; (void)(--j), i += 2) {
     CHECKL(prevSize > esac->_freelists[i]._size);
     b = sacFreeListBlockCheck(&(esac->_freelists[i]));
     if (!b)
@@ -157,7 +157,7 @@ Res SACCreate(SAC *sacReturn, Pool pool, Count classesCount,
   /* Move classes in place */
   /* It's important this matches SACFind. */
   esac = ExternalSACOfSAC(sac);
-  for (j = middleIndex + 1, i = 0; j < classesCount; ++j, i += 2) {
+  for ((void)(j = middleIndex + 1), i = 0; j < classesCount; (void)(++j), i += 2) {
     esac->_freelists[i]._size = classes[j].mps_block_size;
     esac->_freelists[i]._count = 0;
     esac->_freelists[i]._count_max = classes[j].mps_cached_count;
@@ -167,7 +167,7 @@ Res SACCreate(SAC *sacReturn, Pool pool, Count classesCount,
   esac->_freelists[i]._count = 0;
   esac->_freelists[i]._count_max = 0;
   esac->_freelists[i]._blocks = NULL;
-  for (j = middleIndex, i = 1; j > 0; --j, i += 2) {
+  for ((void)(j = middleIndex), i = 1; j > 0; (void)(--j), i += 2) {
     esac->_freelists[i]._size = classes[j-1].mps_block_size;
     esac->_freelists[i]._count = 0;
     esac->_freelists[i]._count_max = classes[j].mps_cached_count;
@@ -268,7 +268,7 @@ Res SACFill(Addr *p_o, SAC sac, Size size)
   if (blockSize == SizeMAX)
     /* .align: align 'cause some classes don't accept unaligned. */
     blockSize = SizeAlignUp(size, PoolAlignment(sac->pool));
-  for (j = 0, fl = esac->_freelists[i]._blocks;
+  for ((void)(j = 0), fl = esac->_freelists[i]._blocks;
        j <= blockCount; ++j) {
     res = PoolAlloc(&p, sac->pool, blockSize);
     if (res != ResOK)
@@ -304,7 +304,7 @@ static void sacClassFlush(SAC sac, Index i, Size blockSize,
   mps_sac_t esac;
 
   esac = ExternalSACOfSAC(sac);
-  for (j = 0, fl = esac->_freelists[i]._blocks;
+  for ((void)(j = 0), fl = esac->_freelists[i]._blocks;
        j < blockCount; ++j) {
     /* @@@@ ignoring shields for now */
     cb = fl; fl = *ADDR_PTR(Addr, cb);
@@ -369,15 +369,15 @@ void SACFlush(SAC sac)
   AVERT(SAC, sac);
 
   esac = ExternalSACOfSAC(sac);
-  for (j = sac->middleIndex + 1, i = 0;
-       j < sac->classesCount; ++j, i += 2) {
+  for ((void)(j = sac->middleIndex + 1), i = 0;
+       j < sac->classesCount; (void)(++j), i += 2) {
     sacClassFlush(sac, i, esac->_freelists[i]._size,
                   esac->_freelists[i]._count);
     AVER(esac->_freelists[i]._blocks == NULL);
   }
   /* no need to flush overlarge, there's nothing there */
   prevSize = esac->_middle;
-  for (j = sac->middleIndex, i = 1; j > 0; --j, i += 2) {
+  for ((void)(j = sac->middleIndex), i = 1; j > 0; (void)(--j), i += 2) {
     sacClassFlush(sac, i, prevSize, esac->_freelists[i]._count);
     AVER(esac->_freelists[i]._blocks == NULL);
     prevSize = esac->_freelists[i]._size;

--- a/code/testlib.c
+++ b/code/testlib.c
@@ -209,8 +209,8 @@ mps_addr_t rnd_addr(void)
   mps_word_t res;
   unsigned bits;
 
-  for (bits = 0, res = 0; bits < ADDR_BITS;
-       bits += 31, res = res << 31 | (mps_word_t)rnd())
+  for ((void)(bits = 0), res = 0; bits < ADDR_BITS;
+       (void)(bits += 31), res = res << 31 | (mps_word_t)rnd())
     NOOP;
   return (mps_addr_t)res;
 }

--- a/code/testlib.c
+++ b/code/testlib.c
@@ -206,12 +206,11 @@ void rnd_verify(int depth)
 
 mps_addr_t rnd_addr(void)
 {
-  mps_word_t res;
+  mps_word_t res = 0;
   unsigned bits;
 
-  for ((void)(bits = 0), res = 0; bits < ADDR_BITS;
-       (void)(bits += 31), res = res << 31 | (mps_word_t)rnd())
-    NOOP;
+  for (bits = 0; bits < ADDR_BITS; bits += 31)
+    res = res << 31 | (mps_word_t)rnd();
   return (mps_addr_t)res;
 }
 

--- a/manual/source/release.rst
+++ b/manual/source/release.rst
@@ -95,6 +95,10 @@ Other changes
 
    .. _GitHub issue #51: https://github.com/Ravenbrook/mps/issues/51
 
+#. The MPS now builds with ``clang -Wcomma``. See `GitHub issue #47`_.
+
+   .. _GitHub issue #47: https://github.com/Ravenbrook/mps/issues/47
+
 
 .. _release-notes-1.117:
 


### PR DESCRIPTION
The -Wcomma option appears to be turned on automatically by Xcode 12.3, so it's a good idea for the MPS to build with the option, to avoid unpleasant surprises when people update their Xcode.

The simplest way to suppress the warning is to cast the left hand side of the comma operator to void.

Fixes #47.