### PR TITLE
Ensure that the MPS builds with Clang 10.

### DIFF
--- a/code/arena.c
+++ b/code/arena.c
@@ -1313,7 +1313,7 @@ void ArenaAccumulateTime(Arena arena, Clock start, Clock end)
 {
   AVERT(Arena, arena);
   AVER(start <= end);
-  arena->tracedTime += (end - start) / (double) ClocksPerSec();
+  arena->tracedTime += (double)(end - start) / (double)ClocksPerSec();
 }
 
 

--- a/code/buffer.c
+++ b/code/buffer.c
@@ -292,13 +292,13 @@ void BufferDetach(Buffer buffer, Pool pool)
     init = BufferGetInit(buffer);
     limit = BufferLimit(buffer);
     spare = AddrOffset(init, limit);
-    buffer->emptySize += spare;
+    buffer->emptySize += (double)spare;
     if (buffer->isMutator) {
-      ArenaGlobals(buffer->arena)->emptyMutatorSize += spare;
-      ArenaGlobals(buffer->arena)->allocMutatorSize +=
-        AddrOffset(buffer->base, init);
+      ArenaGlobals(buffer->arena)->emptyMutatorSize += (double)spare;
+      ArenaGlobals(buffer->arena)->allocMutatorSize
+        += (double)AddrOffset(buffer->base, init);
     } else {
-      ArenaGlobals(buffer->arena)->emptyInternalSize += spare;
+      ArenaGlobals(buffer->arena)->emptyInternalSize += (double)spare;
     }
 
     /* Reset the buffer. */
@@ -541,15 +541,15 @@ void BufferAttach(Buffer buffer, Addr base, Addr limit,
   buffer->poolLimit = limit;
 
   filled = AddrOffset(init, limit);
-  buffer->fillSize += filled;
+  buffer->fillSize += (double)filled;
   if (buffer->isMutator) {
     if (base != init) { /* see <design/buffer#.count.alloc.how> */
       Size prealloc = AddrOffset(base, init);
-      ArenaGlobals(buffer->arena)->allocMutatorSize -= prealloc;
+      ArenaGlobals(buffer->arena)->allocMutatorSize -= (double)prealloc;
     }
-    ArenaGlobals(buffer->arena)->fillMutatorSize += filled;
+    ArenaGlobals(buffer->arena)->fillMutatorSize += (double)filled;
   } else {
-    ArenaGlobals(buffer->arena)->fillInternalSize += filled;
+    ArenaGlobals(buffer->arena)->fillInternalSize += (double)filled;
   }
 
   /* run any class-specific attachment method */

--- a/code/global.c
+++ b/code/global.c
@@ -777,9 +777,9 @@ Bool ArenaStep(Globals globals, double interval, double multiplier)
   clocks_per_sec = ClocksPerSec();
 
   start = now = ClockNow();
-  intervalEnd = start + (Clock)(interval * clocks_per_sec);
+  intervalEnd = start + (Clock)(interval * (double)clocks_per_sec);
   AVER(intervalEnd >= start);
-  availableEnd = start + (Clock)(interval * multiplier * clocks_per_sec);
+  availableEnd = start + (Clock)(interval * multiplier * (double)clocks_per_sec);
   AVER(availableEnd >= start);
 
   /* loop while there is work to do and time on the clock. */

--- a/code/locus.c
+++ b/code/locus.c
@@ -231,7 +231,7 @@ void GenDescEndTrace(GenDesc gen, Trace trace)
   AVER(survived <= genTrace->condemned);
 
   if (genTrace->condemned > 0) {
-    double mortality = 1.0 - survived / (double)genTrace->condemned;
+    double mortality = 1.0 - (double)survived / (double)genTrace->condemned;
     double alpha = LocusMortalityALPHA;
     gen->mortality = gen->mortality * (1 - alpha) + mortality * alpha;
     EVENT8(TraceEndGen, trace->arena, trace, gen, genTrace->condemned,

--- a/code/meter.c
+++ b/code/meter.c
@@ -45,10 +45,10 @@ void MeterAccumulate(Meter meter, Size amount)
     .stddev: stddev = sqrt(meanSquared - mean^2).
    */
   meter->count = count;
-  meter->total = total + amount;
+  meter->total = total + (double)amount;
   meter->meanSquared =
     meanSquared / dcount * (dcount - 1.0)
-    + amount / dcount * amount;
+    + (double)amount / dcount * (double)amount;
   if (amount > meter->max)
     meter->max = amount;
   if (amount < meter->min)

--- a/code/mpm.h
+++ b/code/mpm.h
@@ -573,8 +573,8 @@ extern Size ArenaCommitted(Arena arena);
 extern Size ArenaSpareCommitted(Arena arena);
 extern double ArenaSpare(Arena arena);
 extern void ArenaSetSpare(Arena arena, double spare);
-#define ArenaSpareCommitLimit(arena) ((Size)(ArenaCommitted(arena) * ArenaSpare(arena)))
-#define ArenaCurrentSpare(arena) ((double)ArenaSpareCommitted(arena) / ArenaCommitted(arena))
+#define ArenaSpareCommitLimit(arena) ((Size)((double)ArenaCommitted(arena) * ArenaSpare(arena)))
+#define ArenaCurrentSpare(arena) ((double)ArenaSpareCommitted(arena) / (double)ArenaCommitted(arena))
 
 extern Size ArenaCommitLimit(Arena arena);
 extern Res ArenaSetCommitLimit(Arena arena, Size limit);

--- a/code/mpsicv.c
+++ b/code/mpsicv.c
@@ -331,7 +331,7 @@ static void arena_commit_test(mps_arena_t arena)
   reserved = mps_arena_reserved(arena);
   Insist(0.0 <= spare);
   Insist(spare <= 1.0);
-  Insist(spare_committed <= spare * committed);
+  Insist((double)spare_committed <= spare * (double)committed);
   Insist(spare_committed < committed);
   Insist(committed <= reserved);
   Insist(committed <= limit);

--- a/code/policy.c
+++ b/code/policy.c
@@ -148,7 +148,7 @@ static double policyCollectionTime(Arena arena)
     collectionRate = arena->tracedWork / arena->tracedTime;
   else
     collectionRate = ARENA_DEFAULT_COLLECTION_RATE;
-  collectionTime = collectableSize / collectionRate;
+  collectionTime = (double)collectableSize / collectionRate;
   collectionTime += ARENA_DEFAULT_COLLECTION_OVERHEAD;
 
   return collectionTime;
@@ -189,8 +189,8 @@ Bool PolicyShouldCollectWorld(Arena arena, double availableTime,
   collectionTime = policyCollectionTime(arena);
 
   /* How long since we last collected the world? */
-  sinceLastWorldCollect = ((now - arena->lastWorldCollect) /
-                           (double) clocks_per_sec);
+  sinceLastWorldCollect = (double)(now - arena->lastWorldCollect) /
+    (double)clocks_per_sec;
 
   /* Offered enough time, and long enough since we last did it? */
   return availableTime > collectionTime
@@ -285,11 +285,13 @@ Bool PolicyStartTrace(Trace *traceReturn, Bool *collectWorldReturn,
     sFoundation = (Size)0; /* condemning everything, only roots @@@@ */
     /* @@@@ sCondemned should be scannable only */
     sCondemned = ArenaCommitted(arena) - ArenaSpareCommitted(arena);
-    sSurvivors = (Size)(sCondemned * (1 - TraceWorldMortality));
-    tTracePerScan = sFoundation + (sSurvivors * (1 + TraceCopyScanRATIO));
+    sSurvivors = (Size)((double)sCondemned * (1 - TraceWorldMortality));
+    tTracePerScan = (double)sFoundation
+      + ((double)sSurvivors * (1 + TraceCopyScanRATIO));
     AVER(TraceWorkFactor >= 0);
-    AVER(sSurvivors + tTracePerScan * TraceWorkFactor <= (double)SizeMAX);
-    sConsTrace = (Size)(sSurvivors + tTracePerScan * TraceWorkFactor);
+    AVER((double)sSurvivors + tTracePerScan * TraceWorkFactor
+         <= (double)SizeMAX);
+    sConsTrace = (Size)((double)sSurvivors + tTracePerScan * TraceWorkFactor);
     dynamicDeferral = (double)ArenaAvail(arena) - (double)sConsTrace;
 
     if (dynamicDeferral < 0.0) {
@@ -330,7 +332,8 @@ Bool PolicyStartTrace(Trace *traceReturn, Bool *collectWorldReturn,
         goto failCondemn;
       if (TraceIsEmpty(trace))
         goto nothingCondemned;
-      res = TraceStart(trace, mortality, trace->condemned * TraceWorkFactor);
+      res = TraceStart(trace, mortality,
+                       (double)trace->condemned * TraceWorkFactor);
       /* We don't expect normal GC traces to fail to start. */
       AVER(res == ResOK);
       *traceReturn = trace;
@@ -384,7 +387,8 @@ Bool PolicyPollAgain(Arena arena, Clock start, Bool moreWork, Work tracedWork)
     return TRUE;
 
   /* Is there more work to do and more time to do it in? */
-  moreTime = (ClockNow() - start) < ArenaPauseTime(arena) * ClocksPerSec();
+  moreTime = (double)(ClockNow() - start)
+    < ArenaPauseTime(arena) * (double)ClocksPerSec();
   if (moreWork && moreTime)
     return TRUE;
 

--- a/code/pool.c
+++ b/code/pool.c
@@ -232,7 +232,7 @@ Res PoolAlloc(Addr *pReturn, Pool pool, Size size)
 
   /* All PoolAllocs should advance the allocation clock, so we count */
   /* it all in the fillMutatorSize field. */
-  ArenaGlobals(PoolArena(pool))->fillMutatorSize += size;
+  ArenaGlobals(PoolArena(pool))->fillMutatorSize += (double)size;
 
   EVENT_CRITICAL3(PoolAlloc, pool, *pReturn, size);
 

--- a/code/poolmvff.c
+++ b/code/poolmvff.c
@@ -83,7 +83,7 @@ static void MVFFReduce(MVFF mvff)
      threshold fraction of the total memory. */
 
   totalLand = MVFFTotalLand(mvff);
-  freeLimit = (Size)(LandSize(totalLand) * mvff->spare);
+  freeLimit = (Size)((double)LandSize(totalLand) * mvff->spare);
   freeLand = MVFFFreeLand(mvff);
   freeSize = LandSize(freeLand);
   if (freeSize < freeLimit)

--- a/code/steptest.c
+++ b/code/steptest.c
@@ -120,10 +120,8 @@ static double my_clock(void)
     struct rusage ru;
     getrusage(RUSAGE_SELF, &ru);
     ++ clock_reads;
-    return ((ru.ru_utime.tv_sec +
-             ru.ru_stime.tv_sec) * 1000000.0 +
-            (ru.ru_utime.tv_usec +
-             ru.ru_stime.tv_usec));
+    return (double)(ru.ru_utime.tv_sec + ru.ru_stime.tv_sec) * 1000000.0
+      + (double)(ru.ru_utime.tv_usec + ru.ru_stime.tv_usec);
 }
 #endif
 
@@ -143,7 +141,7 @@ static double clock_time;      /* current estimate of time to read the clock */
 
 static void set_clock_timing(void)
 {
-    long i;
+    double i;
     double t1, t2, t3;
 
     t2 = 0.0;
@@ -402,9 +400,9 @@ static void test(mps_arena_t arena, unsigned long step_period)
     printf("  %"PRIuLONGEST" bytes survived.\n", (ulongest_t)live);
     if (condemned) {
         printf("  Mortality %5.2f%%.\n",
-               (1.0 - ((double)live)/condemned) * 100.0);
+               (1.0 - (double)live/(double)condemned) * 100.0);
         printf("  Condemned fraction %5.2f%%.\n",
-               ((double)condemned/(condemned + not_condemned)) * 100.0);
+               ((double)condemned/(double)(condemned + not_condemned)) * 100.0);
     }
     if (collections) {
         printf("  Condemned per collection %"PRIuLONGEST" bytes.\n",
@@ -420,18 +418,18 @@ static void test(mps_arena_t arena, unsigned long step_period)
 
     printf("Timings:\n");
     print_time("  Allocation took ", alloc_time, "");
-    print_time(", mean ", alloc_time / objs, "");
+    print_time(", mean ", alloc_time / (double)objs, "");
     print_time(", max ", max_alloc_time, ".\n");
     if (steps) {
         printf("  %ld steps took ", steps);
         print_time("", step_time, "");
-        print_time(", mean ", step_time/steps, "");
+        print_time(", mean ", step_time / (double)steps, "");
         print_time(", max ", max_step_time, ".\n");
     }
     if (no_steps) {
         printf("  %ld non-steps took ", no_steps);
         print_time("", no_step_time, "");
-        print_time(", mean ", no_step_time / no_steps, "");
+        print_time(", mean ", no_step_time / (double)no_steps, "");
         print_time(", max ", max_no_step_time, ".\n");
     }
     if (alloc_time > 0.0)
@@ -441,20 +439,20 @@ static void test(mps_arena_t arena, unsigned long step_period)
         printf("  Reclaimed %.2f bytes per us of step.\n",
                (double)(condemned - live)/step_time);
         if (collections > 0) {
-            printf("  Took %.2f steps ", (double)steps/collections);
-            print_time("(", step_time / collections, ") per collection.\n");
+            printf("  Took %.2f steps ", (double)steps / (double)collections);
+            print_time("(", step_time / (double)collections, ") per collection.\n");
         }
     }
     print_time("  Total time ", total_time, ".\n");
     print_time("  Total MPS time ", total_mps_time, "");
     printf(" (%5.2f%%, ", total_mps_time * 100.0 / total_time);
-    print_time("", total_mps_time/alloc_bytes, " per byte, ");
-    print_time("", total_mps_time/objs, " per object)\n");
+    print_time("", total_mps_time / (double)alloc_bytes, " per byte, ");
+    print_time("", total_mps_time / (double)objs, " per object)\n");
     print_time("  (adjusted for clock timing: ",
                total_clock_time,
                " spent reading the clock;\n");
     printf("   %"PRIuLONGEST" clock reads; ", (ulongest_t)clock_reads);
-    print_time("", total_clock_time / clock_reads, " per read;");
+    print_time("", total_clock_time / (double)clock_reads, " per read;");
     print_time(" recently measured as ", clock_time, ").\n");
 
     mps_arena_park(arena);

--- a/code/table.c
+++ b/code/table.c
@@ -160,7 +160,7 @@ Res TableGrow(Table table, Count extraCapacity)
 
   /* Calculate the minimum table length that would allow for the required
      capacity without growing again. */
-  minimum = (Count)(required / SPACEFRACTION);
+  minimum = (Count)((double)required / SPACEFRACTION);
   if (minimum < required)       /* overflow? */
     return ResLIMIT;
 
@@ -295,7 +295,7 @@ Res TableDefine(Table table, TableKey key, TableValue value)
   AVER(key != table->unusedKey);
   AVER(key != table->deletedKey);
 
-  if (table->count >= table->length * SPACEFRACTION) {
+  if ((double)table->count >= (double)table->length * SPACEFRACTION) {
     Res res = TableGrow(table, 1);
     if (res != ResOK)
       return res;

--- a/code/testlib.c
+++ b/code/testlib.c
@@ -217,7 +217,7 @@ mps_addr_t rnd_addr(void)
 
 double rnd_double(void)
 {
-  return rnd() / R_m_float;
+  return (double)rnd() / R_m_float;
 }
 
 static unsigned sizelog2(size_t size)

--- a/code/trace.c
+++ b/code/trace.c
@@ -441,14 +441,14 @@ Res TraceCondemnEnd(double *mortalityReturn, Trace trace)
     }
     AVER(trace->condemned >= condemnedBefore);
     condemnedGen = trace->condemned - condemnedBefore;
-    casualtySize += (Size)(condemnedGen * gen->mortality);
+    casualtySize += (Size)((double)condemnedGen * gen->mortality);
   }
   ShieldRelease(trace->arena);
 
   if (TraceIsEmpty(trace))
     return ResFAIL;
 
-  *mortalityReturn = (double)casualtySize / trace->condemned;
+  *mortalityReturn = (double)casualtySize / (double)trace->condemned;
   return ResOK;
 
 failBegin:
@@ -1601,7 +1601,7 @@ Res TraceStart(Trace trace, double mortality, double finishingTime)
 
   /* Calculate the rate of scanning. */
   {
-    Size sSurvivors = (Size)(trace->condemned * (1.0 - mortality));
+    Size sSurvivors = (Size)((double)trace->condemned * (1.0 - mortality));
     double nPolls = finishingTime / ArenaPollALLOCTIME;
 
     /* There must be at least one poll. */
@@ -1680,7 +1680,7 @@ void TraceAdvance(Trace trace)
 
   newWork = traceWork(trace);
   AVER(newWork >= oldWork);
-  arena->tracedWork += newWork - oldWork;
+  arena->tracedWork += (double)(newWork - oldWork);
 }
 
 
@@ -1721,7 +1721,8 @@ Res TraceStartCollectAll(Trace *traceReturn, Arena arena, TraceStartWhy why)
   res = TraceCondemnEnd(&mortality, trace);
   if(res != ResOK) /* should try some other trace, really @@@@ */
     goto failCondemn;
-  finishingTime = ArenaAvail(arena) - trace->condemned * (1.0 - mortality);
+  finishingTime = (double)ArenaAvail(arena)
+    - (double)trace->condemned * (1.0 - mortality);
   if(finishingTime < 0) {
     /* Run out of time, should really try a smaller collection. @@@@ */
     finishingTime = 0.0;

--- a/manual/source/release.rst
+++ b/manual/source/release.rst
@@ -90,6 +90,11 @@ Other changes
 
    .. _GitHub issue #10: https://github.com/Ravenbrook/mps/issues/10
 
+#. The MPS now builds with Clang 10 and
+   ``-Wimplicit-int-float-conversion``. See `GitHub issue #51`_.
+
+   .. _GitHub issue #51: https://github.com/Ravenbrook/mps/issues/51
+
 
 .. _release-notes-1.117:
 


### PR DESCRIPTION
Clang 10 turns on `-Wimplicit-int-float-conversion`, and on 64-bit platforms this issues a warning that implicit conversions to `double` from `Size` and `unsigned long` "may lose precision".

This commit adds casts to `(double)` for all such conversions. The loss of precision is either impossible in practice (because a double can represent all integers up to 2**53, which is about 9 petabytes, well beyond the addressing capabilities for current CPUs), or else acceptable, because we are accumulating an approximate quantity like "collection work" or "fill size" (that has to cope with loss of precision due in any case), or computing a threshold like the spare commit limit where it is acceptable for it to be somewhat approximate.

Fixes #51 (MPS does not build with clang 10 on Ubuntu 20 x86_64).