### PR TITLE
Support for ARM64: new platforms lia6gc, lia6ll, xca6ll.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,12 +5,19 @@ language: c
 os:
   - linux
   - osx
+arch:
+  - amd64
+  - arm64
 compiler:
   - clang
   - gcc
 matrix:
   exclude:
     - os: osx
+      compiler: gcc
+  exclude:
+    - os: linux
+      arch: arm64
       compiler: gcc
 notifications:
   email:

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,10 +15,6 @@ matrix:
   exclude:
     - os: osx
       compiler: gcc
-  exclude:
-    - os: linux
-      arch: arm64
-      compiler: gcc
 notifications:
   email:
     - mps-travis@ravenbrook.com

--- a/code/.p4ignore
+++ b/code/.p4ignore
@@ -13,6 +13,7 @@ lii6gc
 lii6ll
 w3i3mv
 w3i6mv
+xca6ll
 xci3gc
 xci3ll
 xci6gc

--- a/code/.p4ignore
+++ b/code/.p4ignore
@@ -8,6 +8,7 @@ fri3gc
 fri3ll
 fri6gc
 fri6ll
+lia6gc
 lia6ll
 lii3gc
 lii6gc

--- a/code/.p4ignore
+++ b/code/.p4ignore
@@ -8,6 +8,7 @@ fri3gc
 fri3ll
 fri6gc
 fri6ll
+lia6ll
 lii3gc
 lii6gc
 lii6ll

--- a/code/config.h
+++ b/code/config.h
@@ -576,7 +576,13 @@
    things like thread states.  These definitions fix that. */
 
 #if defined(MPS_OS_XC)
-#if defined(MPS_ARCH_I6)
+#if defined(MPS_ARCH_A6)
+
+#define THREAD_STATE_COUNT ARM_THREAD_STATE64_COUNT
+#define THREAD_STATE_FLAVOR ARM_THREAD_STATE64
+#define THREAD_STATE_S arm_thread_state64_t
+
+#elif defined(MPS_ARCH_I6)
 
 #define THREAD_STATE_COUNT x86_THREAD_STATE64_COUNT
 #define THREAD_STATE_FLAVOR x86_THREAD_STATE64

--- a/code/eventpy.c
+++ b/code/eventpy.c
@@ -15,7 +15,7 @@
 #include "event.h"
 
 /* See <https://docs.python.org/3/library/struct.html#byte-order-size-and-alignment> */
-#if defined(MPS_ARCH_I3) || defined(MPS_ARCH_I6)
+#if defined(MPS_ARCH_A6) || defined(MPS_ARCH_I3) || defined(MPS_ARCH_I6)
 #define BYTE_ORDER "<"
 #else
 #error "Can't determine byte order for platform architecture."

--- a/code/lia6gc.gmk
+++ b/code/lia6gc.gmk
@@ -1,0 +1,55 @@
+# -*- makefile -*-
+#
+# lia6gc.gmk: BUILD FOR LINUX/ARM64/GCC PLATFORM
+#
+# $Id$
+# Copyright (c) 2001-2021 Ravenbrook Limited.  See end of file for license.
+
+PFM = lia6gc
+
+MPMPF = \
+    lockix.c \
+    prmcanan.c \
+    prmcix.c \
+    prmclia6.c \
+    protix.c \
+    protsgix.c \
+    pthrdext.c \
+    span.c \
+    thix.c \
+    vmix.c
+
+LIBS = -lm -lpthread
+
+include gc.gmk
+include comm.gmk
+
+
+# C. COPYRIGHT AND LICENSE
+#
+# Copyright (C) 2001-2021 Ravenbrook Limited <https://www.ravenbrook.com/>.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are
+# met:
+#
+# 1. Redistributions of source code must retain the above copyright
+#    notice, this list of conditions and the following disclaimer.
+#
+# 2. Redistributions in binary form must reproduce the above copyright
+#    notice, this list of conditions and the following disclaimer in the
+#    documentation and/or other materials provided with the
+#    distribution.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+# A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+# HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+# SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+# LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+# DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+# THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+

--- a/code/lia6ll.gmk
+++ b/code/lia6ll.gmk
@@ -1,0 +1,55 @@
+# -*- makefile -*-
+#
+# lia6ll.gmk: BUILD FOR LINUX/ARM64/Clang PLATFORM
+#
+# $Id$
+# Copyright (c) 2001-2021 Ravenbrook Limited.  See end of file for license.
+
+PFM = lia6ll
+
+MPMPF = \
+    lockix.c \
+    prmcanan.c \
+    prmcix.c \
+    prmclia6.c \
+    protix.c \
+    protsgix.c \
+    pthrdext.c \
+    span.c \
+    thix.c \
+    vmix.c
+
+LIBS = -lm -lpthread
+
+include ll.gmk
+include comm.gmk
+
+
+# C. COPYRIGHT AND LICENSE
+#
+# Copyright (C) 2001-2021 Ravenbrook Limited <https://www.ravenbrook.com/>.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are
+# met:
+#
+# 1. Redistributions of source code must retain the above copyright
+#    notice, this list of conditions and the following disclaimer.
+#
+# 2. Redistributions in binary form must reproduce the above copyright
+#    notice, this list of conditions and the following disclaimer in the
+#    documentation and/or other materials provided with the
+#    distribution.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+# A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+# HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+# SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+# LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+# DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+# THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+

--- a/code/ll.gmk
+++ b/code/ll.gmk
@@ -14,11 +14,11 @@ CFLAGSDEBUG = -O0 -g3
 CFLAGSOPT = -O2 -g3
 
 # Warnings that might be enabled by clients <design/config/#.warning.impl>.
+# TODO: add -Wcomma when all our continuous integration platforms support it.
 CFLAGSCOMPILER := \
 	-Waggregate-return \
 	-Wall \
 	-Wcast-qual \
-	-Wcomma \
 	-Wconversion \
 	-Wduplicate-enum \
 	-Werror \

--- a/code/mps.c
+++ b/code/mps.c
@@ -182,6 +182,21 @@
 #include "prmcfri6.c"   /* x86-64 for FreeBSD mutator context */
 #include "span.c"       /* generic stack probe */
 
+/* Linux on ARM64 with Clang */
+
+#elif defined(MPS_PF_LIA6LL)
+
+#include "lockix.c"     /* Posix locks */
+#include "thix.c"       /* Posix threading */
+#include "pthrdext.c"   /* Posix thread extensions */
+#include "vmix.c"       /* Posix virtual memory */
+#include "protix.c"     /* Posix protection */
+#include "protsgix.c"   /* Posix signal handling */
+#include "prmcanan.c"   /* generic architecture mutator context */
+#include "prmcix.c"     /* Posix mutator context */
+#include "prmclia6.c"   /* x86-64 for Linux mutator context */
+#include "span.c"       /* generic stack probe */
+
 /* Linux on IA-32 with GCC */
 
 #elif defined(MPS_PF_LII3GC)

--- a/code/mps.c
+++ b/code/mps.c
@@ -182,9 +182,9 @@
 #include "prmcfri6.c"   /* x86-64 for FreeBSD mutator context */
 #include "span.c"       /* generic stack probe */
 
-/* Linux on ARM64 with Clang */
+/* Linux on ARM64 with GCC or Clang */
 
-#elif defined(MPS_PF_LIA6LL)
+#elif defined(MPS_PF_LIA6GC) || defined(MPS_PF_LIA6LL)
 
 #include "lockix.c"     /* Posix locks */
 #include "thix.c"       /* Posix threading */

--- a/code/mps.c
+++ b/code/mps.c
@@ -110,6 +110,20 @@
 #include "prmcanan.c"   /* generic architecture mutator context */
 #include "span.c"       /* generic stack probe */
 
+/* macOS on ARM64 built with Clang */
+
+#elif defined(MPS_PF_XCA6LL)
+
+#include "lockix.c"     /* Posix locks */
+#include "thxc.c"       /* macOS Mach threading */
+#include "vmix.c"       /* Posix virtual memory */
+#include "protix.c"     /* Posix protection */
+#include "protxc.c"     /* macOS Mach exception handling */
+#include "prmcanan.c"   /* generic architecture mutator context */
+#include "prmcxc.c"     /* macOS mutator context */
+#include "prmcxca6.c"   /* ARM64 for macOS mutator context */
+#include "span.c"       /* generic stack probe */
+
 /* macOS on IA-32 built with Clang or GCC */
 
 #elif defined(MPS_PF_XCI3LL) || defined(MPS_PF_XCI3GC)

--- a/code/mpstd.h
+++ b/code/mpstd.h
@@ -222,6 +222,25 @@
 #define MPS_PF_ALIGN    8
 
 
+/* Clang/LLVM 10.0, clang -E -dM */
+
+#elif defined(__linux__) && defined(__aarch64__) && defined(__GNUC__) \
+      && defined(__clang__)
+#if defined(CONFIG_PF_STRING) && ! defined(CONFIG_PF_LIA6LL)
+#error "specified CONFIG_PF_... inconsistent with detected lia6ll"
+#endif
+#define MPS_PF_LIA6LL
+#define MPS_PF_STRING   "lia6ll"
+#define MPS_OS_LI
+#define MPS_ARCH_A6
+#define MPS_BUILD_LL
+#define MPS_T_WORD      unsigned long
+#define MPS_T_ULONGEST  unsigned long
+#define MPS_WORD_WIDTH  64
+#define MPS_WORD_SHIFT  6
+#define MPS_PF_ALIGN    8
+
+
 /* GCC 2.6.3, gcc -E -dM
  * The actual granularity of GNU malloc is 8, but field alignments are
  * all 4.

--- a/code/mpstd.h
+++ b/code/mpstd.h
@@ -222,6 +222,25 @@
 #define MPS_PF_ALIGN    8
 
 
+/* GCC 7.5, gcc -E -dM */
+
+#elif defined(__linux__) && defined(__aarch64__) && defined(__GNUC__) \
+      && !defined(__clang__)
+#if defined(CONFIG_PF_STRING) && ! defined(CONFIG_PF_LIA6GC)
+#error "specified CONFIG_PF_... inconsistent with detected lia6gc"
+#endif
+#define MPS_PF_LIA6GC
+#define MPS_PF_STRING   "lia6gc"
+#define MPS_OS_LI
+#define MPS_ARCH_A6
+#define MPS_BUILD_GC
+#define MPS_T_WORD      unsigned long
+#define MPS_T_ULONGEST  unsigned long
+#define MPS_WORD_WIDTH  64
+#define MPS_WORD_SHIFT  6
+#define MPS_PF_ALIGN    8
+
+
 /* Clang/LLVM 10.0, clang -E -dM */
 
 #elif defined(__linux__) && defined(__aarch64__) && defined(__GNUC__) \

--- a/code/mpstd.h
+++ b/code/mpstd.h
@@ -165,6 +165,25 @@
 #define MPS_PF_ALIGN    8
 
 
+/* Apple clang version 12.0, clang -E -dM */
+
+#elif defined(__APPLE__) && defined(__arm64__) && defined(__MACH__) \
+      && defined(__clang__)
+#if defined(CONFIG_PF_STRING) && ! defined(CONFIG_PF_XCA6LL)
+#error "specified CONFIG_PF_... inconsistent with detected xca6ll"
+#endif
+#define MPS_PF_XCA6LL
+#define MPS_PF_STRING   "xca6ll"
+#define MPS_OS_XC
+#define MPS_ARCH_A6
+#define MPS_BUILD_LL
+#define MPS_T_WORD      unsigned long
+#define MPS_T_ULONGEST  unsigned long
+#define MPS_WORD_WIDTH  64
+#define MPS_WORD_SHIFT  6
+#define MPS_PF_ALIGN    8
+
+
 /* Apple clang version 3.1, clang -E -dM */
 
 #elif defined(__APPLE__) && defined(__i386__) && defined(__MACH__) \

--- a/code/prmclia6.c
+++ b/code/prmclia6.c
@@ -1,0 +1,53 @@
+/* prmclia6.c: MUTATOR CONTEXT ARM64 (LINUX)
+ *
+ * $Id$
+ * Copyright (c) 2001-2021 Ravenbrook Limited.  See end of file for license.
+ *
+ * .purpose: Implement the mutator context module. <design/prmc>.
+ */
+
+#include "prmcix.h"
+
+SRCID(prmclia6, "$Id$");
+
+#if !defined(MPS_OS_LI) || !defined(MPS_ARCH_A6)
+#error "prmclia6.c is specific to MPS_OS_LI and MPS_ARCH_A6"
+#endif
+
+
+Addr MutatorContextSP(MutatorContext context)
+{
+  AVERT(MutatorContext, context);
+
+  return (Addr)context->ucontext->uc_mcontext.sp;
+}
+
+
+/* C. COPYRIGHT AND LICENSE
+ *
+ * Copyright (C) 2001-2021 Ravenbrook Limited <https://www.ravenbrook.com/>.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are
+ * met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the
+ *    distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+ * IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED
+ * TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+ * PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */

--- a/code/prmcxca6.c
+++ b/code/prmcxca6.c
@@ -1,44 +1,35 @@
-/* prmcxc.h: MUTATOR CONTEXT (macOS)
+/* prmcxca6.c: MUTATOR CONTEXT ARM64 (macOS)
  *
  * $Id$
- * Copyright (c) 2001-2020 Ravenbrook Limited.  See end of file for license.
+ * Copyright (c) 2001-2021 Ravenbrook Limited.  See end of file for license.
  *
- * .readership: MPS developers.
+ * .purpose: Implement the mutator context module. <design/prmc>.
+ *
+ *
+ * ASSUMPTIONS
+ *
+ * .sp: The stack pointer in the context is SP.
  */
 
-#ifndef prmcxc_h
-#define prmcxc_h
+#include "prmcxc.h"
 
-#include "mpm.h"
+SRCID(prmcxca6, "$Id$");
 
-#include <mach/mach_types.h>
-#if defined(MPS_ARCH_A6)
-#include <mach/arm/thread_status.h>
-#elif defined(MPS_ARCH_I3) || defined(MPS_ARCH_I6)
-#include <mach/i386/thread_status.h>
-#else
-#error "Unknown macOS architecture"
+#if !defined(MPS_OS_XC) || !defined(MPS_ARCH_A6)
+#error "prmcxca6.c is specific to MPS_OS_XC and MPS_ARCH_A6"
 #endif
 
-typedef struct MutatorContextStruct {
-  Sig sig;                      /* <design/sig> */
-  MutatorContextVar var;        /* Discriminator. */
-  Addr address;                 /* Fault address, if stopped by protection
-                                 * fault; NULL if stopped by thread manager. */
-  THREAD_STATE_S *threadState;
-  /* FIXME: Might need to get the floats in case the compiler stashes
-     intermediate values in them. */
-} MutatorContextStruct;
 
-extern void MutatorContextInitFault(MutatorContext context, Addr address, THREAD_STATE_S *threadState);
-extern void MutatorContextInitThread(MutatorContext context, THREAD_STATE_S *threadState);
-
-#endif /* prmcxc_h */
+Addr MutatorContextSP(MutatorContext context)
+{
+  AVERT(MutatorContext, context);
+  return (Addr)arm_thread_state64_get_sp(*(context->threadState));   /* .sp */
+}
 
 
 /* C. COPYRIGHT AND LICENSE
  *
- * Copyright (C) 2001-2020 Ravenbrook Limited <https://www.ravenbrook.com/>.
+ * Copyright (C) 2001-2021 Ravenbrook Limited <https://www.ravenbrook.com/>.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are

--- a/code/protxc.c
+++ b/code/protxc.c
@@ -70,7 +70,6 @@
 #include <mach/thread_act.h>
 #include <mach/thread_status.h>
 #include <mach/mach_error.h>
-#include <mach/i386/thread_status.h>
 #include <mach/exc.h>
 #include <pthread.h>
 #include <stdlib.h> /* see .trans.stdlib */

--- a/code/testlib.h
+++ b/code/testlib.h
@@ -104,7 +104,7 @@
  * tests to root out any incompatible assumptions by breaking.
  */
 
-#if defined(MPS_ARCH_I6)
+#if defined(MPS_ARCH_A6) || defined(MPS_ARCH_I6)
 #define PRIwWORD "16"
 #elif defined(MPS_ARCH_I3)
 #define PRIwWORD "8"

--- a/code/xca6ll.gmk
+++ b/code/xca6ll.gmk
@@ -1,0 +1,58 @@
+# -*- makefile -*-
+#
+# xca6ll.gmk: BUILD FOR macOS/ARM64/Clang/LLVM PLATFORM
+#
+# $Id$
+# Copyright (c) 2001-2021 Ravenbrook Limited.  See end of file for license.
+#
+# .prefer.xcode: The documented and preferred way to develop the MPS
+# for this platform is to use the Xcode project (mps.xcodeproj). This
+# makefile provides a way to compile the MPS one source file at a
+# time, rather than all at once via mps.c (which can hide errors due
+# to missing headers).
+
+PFM = xca6ll
+
+MPMPF = \
+    lockix.c \
+    prmcanan.c \
+    prmcxc.c \
+    prmcxca6.c \
+    protix.c \
+    protxc.c \
+    span.c \
+    thxc.c \
+    vmix.c
+
+include ll.gmk
+include comm.gmk
+
+
+# C. COPYRIGHT AND LICENSE
+#
+# Copyright (C) 2001-2021 Ravenbrook Limited <https://www.ravenbrook.com/>.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are
+# met:
+#
+# 1. Redistributions of source code must retain the above copyright
+#    notice, this list of conditions and the following disclaimer.
+#
+# 2. Redistributions in binary form must reproduce the above copyright
+#    notice, this list of conditions and the following disclaimer in the
+#    documentation and/or other materials provided with the
+#    distribution.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+# A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+# HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+# SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+# LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+# DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+# THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+

--- a/configure
+++ b/configure
@@ -3454,6 +3454,14 @@ CLEAN_TARGET=clean-make-build
 INSTALL_TARGET=install-make-build
 TEST_TARGET=test-make-build
 case $host/$CLANG in
+  aarch64-*-linux*/yes)
+      { $as_echo "$as_me:${as_lineno-$LINENO}: result: Linux ARM64" >&5
+$as_echo "Linux ARM64" >&6; }
+      MPS_OS_NAME=li
+      MPS_ARCH_NAME=a6
+      MPS_BUILD_NAME=ll
+      PFMCFLAGS="$CFLAGS_LL"
+    ;;
   i*86-*-linux*/no)
       { $as_echo "$as_me:${as_lineno-$LINENO}: result: Linux x86" >&5
 $as_echo "Linux x86" >&6; }

--- a/configure
+++ b/configure
@@ -3478,6 +3478,18 @@ $as_echo "Linux x86_64" >&6; }
       MPS_BUILD_NAME=ll
       PFMCFLAGS="$CFLAGS_LL"
     ;;
+  aarch64-*-darwin*/*)
+      { $as_echo "$as_me:${as_lineno-$LINENO}: result: Mac OS X ARM64" >&5
+$as_echo "Mac OS X ARM64" >&6; }
+      MPS_OS_NAME=xc
+      MPS_ARCH_NAME=a6
+      MPS_BUILD_NAME=ll
+      BUILD_TARGET=build-via-xcode
+      CLEAN_TARGET=clean-xcode-build
+      INSTALL_TARGET=install-xcode-build
+      TEST_TARGET=test-xcode-build
+      PFMCFLAGS="$CFLAGS_LL"
+    ;;
   i*86-*-darwin*/*)
       { $as_echo "$as_me:${as_lineno-$LINENO}: result: Mac OS X x86" >&5
 $as_echo "Mac OS X x86" >&6; }

--- a/configure
+++ b/configure
@@ -3454,6 +3454,14 @@ CLEAN_TARGET=clean-make-build
 INSTALL_TARGET=install-make-build
 TEST_TARGET=test-make-build
 case $host/$CLANG in
+  aarch64-*-linux*/no)
+      { $as_echo "$as_me:${as_lineno-$LINENO}: result: Linux ARM64" >&5
+$as_echo "Linux ARM64" >&6; }
+      MPS_OS_NAME=li
+      MPS_ARCH_NAME=a6
+      MPS_BUILD_NAME=gc
+      PFMCFLAGS="$CFLAGS_GC"
+    ;;
   aarch64-*-linux*/yes)
       { $as_echo "$as_me:${as_lineno-$LINENO}: result: Linux ARM64" >&5
 $as_echo "Linux ARM64" >&6; }

--- a/configure.ac
+++ b/configure.ac
@@ -45,6 +45,13 @@ CLEAN_TARGET=clean-make-build
 INSTALL_TARGET=install-make-build
 TEST_TARGET=test-make-build
 case $host/$CLANG in
+  aarch64-*-linux*/yes)
+      AC_MSG_RESULT([Linux ARM64])
+      MPS_OS_NAME=li
+      MPS_ARCH_NAME=a6
+      MPS_BUILD_NAME=ll
+      PFMCFLAGS="$CFLAGS_LL"
+    ;;
   i*86-*-linux*/no)
       AC_MSG_RESULT([Linux x86])
       MPS_OS_NAME=li

--- a/configure.ac
+++ b/configure.ac
@@ -66,6 +66,17 @@ case $host/$CLANG in
       MPS_BUILD_NAME=ll
       PFMCFLAGS="$CFLAGS_LL"
     ;;
+  aarch64-*-darwin*/*)
+      AC_MSG_RESULT([Mac OS X ARM64])
+      MPS_OS_NAME=xc
+      MPS_ARCH_NAME=a6
+      MPS_BUILD_NAME=ll
+      BUILD_TARGET=build-via-xcode
+      CLEAN_TARGET=clean-xcode-build
+      INSTALL_TARGET=install-xcode-build
+      TEST_TARGET=test-xcode-build
+      PFMCFLAGS="$CFLAGS_LL"
+    ;;
   i*86-*-darwin*/*)
       AC_MSG_RESULT([Mac OS X x86])
       MPS_OS_NAME=xc

--- a/configure.ac
+++ b/configure.ac
@@ -45,6 +45,13 @@ CLEAN_TARGET=clean-make-build
 INSTALL_TARGET=install-make-build
 TEST_TARGET=test-make-build
 case $host/$CLANG in
+  aarch64-*-linux*/no)
+      AC_MSG_RESULT([Linux ARM64])
+      MPS_OS_NAME=li
+      MPS_ARCH_NAME=a6
+      MPS_BUILD_NAME=gc
+      PFMCFLAGS="$CFLAGS_GC"
+    ;;
   aarch64-*-linux*/yes)
       AC_MSG_RESULT([Linux ARM64])
       MPS_OS_NAME=li

--- a/design/prmc.txt
+++ b/design/prmc.txt
@@ -268,13 +268,14 @@ macOS implementation
 
 _`.impl.xc`: In ``prmcix.c`` and ``prmcxc.c``, with processor-specific
 parts in ``prmci3.c`` and ``prmci6.c``, and other platform-specific
-parts in ``prmcxci3.c`` and ``prmcxci6.c``.
+parts in ``prmcxca6.c``, ``prmcxci3.c`` and ``prmcxci6.c``.
 
 _`.impl.xc.context`: The context consists of the
 ``__Request__mach_exception_raise_state_identity_t`` and
-``x86_thread_state32_t`` or ``x86_thread_state64_t`` structures. There
-doesn't seem to be any documentation for these structures, but they
-are defined in the Mach headers.
+``arm_thread_state_t``, ``x86_thread_state32_t`` or
+``x86_thread_state64_t`` structures. There doesn't seem to be any
+documentation for these structures, but they are defined in the Mach
+headers.
 
 _`.impl.xc.fault.addr`: ``__Request__mach_exception_raise_state_identity_t.code[1]`` is the
 address that the faulting instruction was trying to access.
@@ -292,9 +293,11 @@ calling |thread_get_state|_.
 .. _thread_get_state: https://www.gnu.org/software/hurd/gnumach-doc/Thread-Execution.html
 
 _`.impl.xc.context.scan`: The thread's registers are found in the
-``x86_thread_state32_t`` or ``x86_thread_state64_t`` structure.
+``arm_thread_state64_t``, ``x86_thread_state32_t`` or
+``x86_thread_state64_t`` structure.
 
-_`.impl.xc.context.sp`: The stack pointer is obtained from
+_`.impl.xc.context.sp`: The stack pointer is obtained using the
+``arm_thread_state64_get_sp()`` macro (on ARM64), or from
 ``x86_thread_state32_t.__esp`` (on IA-32) or
 ``x86_thread_state64_t.__rsp`` (on x86-64).
 

--- a/design/prmc.txt
+++ b/design/prmc.txt
@@ -178,8 +178,8 @@ Posix implementation
 
 _`.impl.ix`: In ``prmcix.c`` and ``protsgix.c``, with
 processor-specific parts in ``prmci3.c`` and ``prmci6.c``, and other
-platform-specific parts in ``prmcfri3.c``, ``prmclii3.c``,
-``prmcfri6.c``, and ``prmclii6.c``.
+platform-specific parts in ``prmcfri3.c``, ``prmcfri6.c``,
+``prmclia6.c``, ``prmclii3.c``, and ``prmclii6.c``.
 
 _`.impl.ix.context`: The context consists of the |siginfo_t|_ and
 |ucontext_t|_ structures. POSIX specifies some of the fields in

--- a/manual/build.txt
+++ b/manual/build.txt
@@ -139,6 +139,7 @@ Platform     OS          Architecture    Compiler      Makefile
 ``fri3ll``   FreeBSD     IA-32           Clang         ``fri3ll.gmk``
 ``fri6gc``   FreeBSD     x86-64          GCC           ``fri6gc.gmk``
 ``fri6ll``   FreeBSD     x86-64          Clang         ``fri6ll.gmk``
+``lia6ll``   Linux       ARM64           Clang         ``lia6ll.gmk``
 ``lii3gc``   Linux       IA-32           GCC           ``lii3gc.gmk``
 ``lii6gc``   Linux       x86-64          GCC           ``lii6gc.gmk``
 ``lii6ll``   Linux       x86-64          Clang         ``lii6ll.gmk``

--- a/manual/build.txt
+++ b/manual/build.txt
@@ -139,6 +139,7 @@ Platform     OS          Architecture    Compiler      Makefile
 ``fri3ll``   FreeBSD     IA-32           Clang         ``fri3ll.gmk``
 ``fri6gc``   FreeBSD     x86-64          GCC           ``fri6gc.gmk``
 ``fri6ll``   FreeBSD     x86-64          Clang         ``fri6ll.gmk``
+``lia6gc``   Linux       ARM64           GCC           ``lia6gc.gmk``
 ``lia6ll``   Linux       ARM64           Clang         ``lia6ll.gmk``
 ``lii3gc``   Linux       IA-32           GCC           ``lii3gc.gmk``
 ``lii6gc``   Linux       x86-64          GCC           ``lii6gc.gmk``

--- a/manual/build.txt
+++ b/manual/build.txt
@@ -144,6 +144,7 @@ Platform     OS          Architecture    Compiler      Makefile
 ``lii6ll``   Linux       x86-64          Clang         ``lii6ll.gmk``
 ``w3i3mv``   Windows     IA-32           Microsoft C   ``w3i3mv.nmk``
 ``w3i6mv``   Windows     x86-64          Microsoft C   ``w3i6mv.nmk``
+``xca6ll``   macOS       ARM64           Clang         ``mps.xcodeproj``
 ``xci3ll``   macOS       IA-32           Clang         ``mps.xcodeproj``
 ``xci6ll``   macOS       x86-64          Clang         ``mps.xcodeproj``
 ==========   =========   =============   ============  =================

--- a/manual/source/code-index.rst
+++ b/manual/source/code-index.rst
@@ -385,6 +385,7 @@ fri6gc.gmk     GNU makefile for platform FRI6GC.
 fri6ll.gmk     GNU makefile for platform FRI6LL.
 gc.gmk         GNU make fragment for GCC.
 gp.gmk         GNU make fragment for GCC/GProf (broken).
+lia6gc.gmk     GNU makefile for platform LIA6GC.
 lia6ll.gmk     GNU makefile for platform LIA6LL.
 lii3gc.gmk     GNU makefile for platform LII3GC.
 lii6gc.gmk     GNU makefile for platform LII6GC.

--- a/manual/source/code-index.rst
+++ b/manual/source/code-index.rst
@@ -183,6 +183,7 @@ prmcw3i3.c    Mutator context implementation for Windows, IA-32.
 prmcw3i6.c    Mutator context implementation for Windows, x86-64.
 prmcxc.c      Mutator context implementation for macOS.
 prmcxc.h      Mutator context interface for macOS.
+prmcxca6.c    Mutator context implementation for macOS, ARM64.
 prmcxci3.c    Mutator context implementation for macOS, IA-32.
 prmcxci6.c    Mutator context implementation for macOS, x86-64.
 prot.h        Protection interface. See design.mps.prot_.
@@ -393,6 +394,7 @@ w3i3mv.nmk     NMAKE file for platform W3I3MV.
 w3i3pc.nmk     NMAKE file for platform W3I3PC.
 w3i6mv.nmk     NMAKE file for platform W3I6MV.
 w3i6pc.nmk     NMAKE file for platform W3I6PC.
+xca6ll.gmk     GNU makefile for platform XCA6LL.
 xci3gc.gmk     GNU makefile for platform XCI3GC.
 xci3ll.gmk     GNU makefile for platform XCI3LL.
 xci6gc.gmk     GNU makefile for platform XCI6GC.

--- a/manual/source/code-index.rst
+++ b/manual/source/code-index.rst
@@ -175,6 +175,7 @@ prmci6.c      Mutator context implementation for x86-64.
 prmci6.h      Mutator context interface for x86-64.
 prmcix.c      Mutator context implementation for POSIX.
 prmcix.h      Mutator context interface for POSIX.
+prmclia6.c    Mutator context implementation for Linux, ARM64.
 prmclii3.c    Mutator context implementation for Linux, IA-32.
 prmclii6.c    Mutator context implementation for Linux, x86-64.
 prmcw3.c      Mutator context implementation for Windows.
@@ -384,6 +385,7 @@ fri6gc.gmk     GNU makefile for platform FRI6GC.
 fri6ll.gmk     GNU makefile for platform FRI6LL.
 gc.gmk         GNU make fragment for GCC.
 gp.gmk         GNU make fragment for GCC/GProf (broken).
+lia6ll.gmk     GNU makefile for platform LIA6LL.
 lii3gc.gmk     GNU makefile for platform LII3GC.
 lii6gc.gmk     GNU makefile for platform LII6GC.
 lii6ll.gmk     GNU makefile for platform LII6LL.

--- a/manual/source/release.rst
+++ b/manual/source/release.rst
@@ -12,6 +12,8 @@ Release 1.118.0
 New features
 ............
 
+#. New supported platform ``xca6ll`` (macOS, ARM64, Clang/LLVM).
+
 #. The MPS no longer supports building for the xci3ll platform (macOS,
    IA-32, Clang/LLVM) using Xcode. This is because Xcode 10.0 no
    longer supports this platform. The platform is still supported via

--- a/manual/source/release.rst
+++ b/manual/source/release.rst
@@ -12,7 +12,10 @@ Release 1.118.0
 New features
 ............
 
-#. New supported platform ``xca6ll`` (macOS, ARM64, Clang/LLVM).
+#. New supported platforms:
+
+   * ``lia6ll`` (Linux, ARM64, Clang/LLVM).
+   * ``xca6ll`` (macOS, ARM64, Clang/LLVM).
 
 #. The MPS no longer supports building for the xci3ll platform (macOS,
    IA-32, Clang/LLVM) using Xcode. This is because Xcode 10.0 no

--- a/manual/source/release.rst
+++ b/manual/source/release.rst
@@ -14,6 +14,7 @@ New features
 
 #. New supported platforms:
 
+   * ``lia6gc`` (Linux, ARM64, GCC).
    * ``lia6ll`` (Linux, ARM64, Clang/LLVM).
    * ``xca6ll`` (macOS, ARM64, Clang/LLVM).
 

--- a/manual/source/topic/platform.rst
+++ b/manual/source/topic/platform.rst
@@ -171,6 +171,13 @@ Platform interface
     x86-64 processor architecture, and the Clang/LLVM compiler.
 
 
+.. c:macro:: MPS_PF_LIA6LL
+
+    A :term:`C` preprocessor macro that indicates, if defined, that
+    the :term:`platform` consists of the Linux operating system, the
+    ARM64 processor architecture, and the Clang/LLVM compiler.
+
+
 .. c:macro:: MPS_PF_LII3GC
 
     A :term:`C` preprocessor macro that indicates, if defined, that
@@ -370,6 +377,7 @@ Platform    Status
 ``fri6ll``  Supported
 ``i5m2cc``  *Not supported*
 ``iam4cc``  *Not supported*
+``lia6ll``  Supported
 ``lii3eg``  *Not supported*
 ``lii3gc``  Supported
 ``lii4gc``  Corrected to ``lii3gc``

--- a/manual/source/topic/platform.rst
+++ b/manual/source/topic/platform.rst
@@ -28,6 +28,7 @@ The second pair of characters names the processor architecture:
 ======  ======================  ======================
 ``AR``  Processor architecture  Constant
 ======  ======================  ======================
+``a6``  ARM64                   :c:macro:`MPS_ARCH_A6`
 ``i3``  Intel/AMD IA-32         :c:macro:`MPS_ARCH_I3`
 ``i6``  Intel/AMD x86-64        :c:macro:`MPS_ARCH_I6`
 ======  ======================  ======================
@@ -64,6 +65,13 @@ Platform interface
 ::
 
     #include "mpstd.h"
+
+
+.. c:macro:: MPS_ARCH_A6
+
+    A :term:`C` preprocessor macro that indicates, if defined, that
+    the target processor architecture of the compilation is a member
+    of the ARM64 family of 64-bit processors.
 
 
 .. c:macro:: MPS_ARCH_I3
@@ -204,6 +212,13 @@ Platform interface
     the :term:`platform` consists of the Windows operating system, the
     x86-64 processor architecture, and the Microsoft Visual C/C++
     compiler.
+
+
+.. c:macro:: MPS_PF_XCA6LL
+
+    A :term:`C` preprocessor macro that indicates, if defined, that
+    the :term:`platform` consists of the macOS operating system, the
+    ARM64 processor architecture, and the Clang/LLVM compiler.
 
 
 .. c:macro:: MPS_PF_XCI3GC
@@ -378,6 +393,7 @@ Platform    Status
 ``w3i6mv``  Supported
 ``w3i6pc``  *Not supported*
 ``w3ppmv``  *Not supported*
+``xca6ll``  Supported
 ``xci3gc``  *Not supported*
 ``xci3ll``  Supported
 ``xci6gc``  *Not supported*

--- a/manual/source/topic/platform.rst
+++ b/manual/source/topic/platform.rst
@@ -171,6 +171,13 @@ Platform interface
     x86-64 processor architecture, and the Clang/LLVM compiler.
 
 
+.. c:macro:: MPS_PF_LIA6GC
+
+    A :term:`C` preprocessor macro that indicates, if defined, that
+    the :term:`platform` consists of the Linux operating system, the
+    ARM64 processor architecture, and the GCC compiler.
+
+
 .. c:macro:: MPS_PF_LIA6LL
 
     A :term:`C` preprocessor macro that indicates, if defined, that
@@ -377,6 +384,7 @@ Platform    Status
 ``fri6ll``  Supported
 ``i5m2cc``  *Not supported*
 ``iam4cc``  *Not supported*
+``lia6gc``  Supported
 ``lia6ll``  Supported
 ``lii3eg``  *Not supported*
 ``lii3gc``  Supported

--- a/manual/source/topic/porting.rst
+++ b/manual/source/topic/porting.rst
@@ -76,8 +76,9 @@ usable.
    stack` can be scanned.
 
    See :ref:`design-prmc` for the design, and ``prmc.h`` for the
-   interface. There are implementations on Unix and Windows for
-   IA-32 and x86-64, and on macOS for IA-32, x86-64, and ARM64.
+   interface. There are implementations on FreeBSD and Windows for
+   IA-32 and x86-64, and on Linux and macOS for IA-32, x86-64, and
+   ARM64.
 
    There is a generic implementation in ``prmcan.c``, which can't
    provide these features, and so only supports a single thread.

--- a/manual/source/topic/porting.rst
+++ b/manual/source/topic/porting.rst
@@ -76,8 +76,8 @@ usable.
    stack` can be scanned.
 
    See :ref:`design-prmc` for the design, and ``prmc.h`` for the
-   interface. There are implementations on Unix, Windows, and macOS for
-   IA-32 and x86-64.
+   interface. There are implementations on Unix and Windows for
+   IA-32 and x86-64, and on macOS for IA-32, x86-64, and ARM64.
 
    There is a generic implementation in ``prmcan.c``, which can't
    provide these features, and so only supports a single thread.

--- a/tool/testcases.txt
+++ b/tool/testcases.txt
@@ -5,7 +5,7 @@ abqtest
 airtest
 amcss          =P
 amcsshe        =P
-amcssth        =P =T
+amcssth        =P =T =A
 amsss          =P
 amssshe        =P
 apss
@@ -48,6 +48,7 @@ zmess
 Key to flags
 ............
 
+    A -- fails on Arm64 (see GitHub issue #59)
     B -- known Bad
     L -- Long runtime
     N -- Not an automated test case

--- a/tool/testrun.sh
+++ b/tool/testrun.sh
@@ -27,17 +27,24 @@ echo "MPS test suite"
 TEST_RUNNER=
 TEST_CASES=
 
+# Architecture exclusions.
+case $(uname -m) in
+    aarch64*|arm64*|armv8*) EXCLUDE_ARCH=A ;;
+    *) EXCLUDE_ARCH= ;;
+esac
+
 # Parse command-line arguments.
 while [ $# -gt 0 ]; do
-    case "$1" in
+    case $1 in
         -s)
             TEST_SUITE=$2
-            case "$TEST_SUITE" in
-                testrun)      EXCLUDE="LNW"   ;;
-                testci)       EXCLUDE="BNW"   ;;
-                testall)      EXCLUDE="NW"    ;;
-                testansi)     EXCLUDE="LNTW"  ;;
-                testpollnone) EXCLUDE="LNPTW" ;;
+            # Test-suite exclusions.
+            case $TEST_SUITE in
+                testrun)      EXCLUDE_SUITE=LNW   ;;
+                testci)       EXCLUDE_SUITE=BNW   ;;
+                testall)      EXCLUDE_SUITE=NW    ;;
+                testansi)     EXCLUDE_SUITE=LNTW  ;;
+                testpollnone) EXCLUDE_SUITE=LNPTW ;;
                 *)
                     echo "Test suite $TEST_SUITE not recognized."
                     exit 1 ;;
@@ -45,8 +52,8 @@ while [ $# -gt 0 ]; do
             echo "Test suite: $TEST_SUITE"
             TEST_CASE_DB=$(dirname -- "$0")/testcases.txt
             TEST_CASES=$(<"$TEST_CASE_DB" grep -e '^[a-z]' |
-                                grep -v -e "=[$EXCLUDE]" |
-                                cut -d' ' -f1)
+                             grep -v -e "=[${EXCLUDE_ARCH}${EXCLUDE_SUITE}]" |
+                             cut -d' ' -f1)
             shift 2
             ;;
         -r)


### PR DESCRIPTION
Fixes #46 (MPS does not build with "./configure && make" on macOS with Xcode 12.3)
Fixes #50 (MPS does not support the ARM64 CPU) by adding three new supported platforms.