### PR TITLE
Prevent races between threads in amcssth.

### DIFF
--- a/code/testthr.h
+++ b/code/testthr.h
@@ -24,8 +24,9 @@ typedef void *(*testthr_routine_t)(void *);
 
 
 /* testthr_t -- type of thread identifiers
+ * testthr_mutex_t -- type of mutexes
  *
- * It is necessary to define it here (even though it requires some
+ * It is necessary to define these here (even though it requires some
  * #ifdefs) so that clients can allocate storage for them.
  */
 
@@ -45,6 +46,8 @@ typedef struct testthr_t {
   void *result;               /* result returned from start */
 } testthr_t;
 
+typedef CRITICAL_SECTION testthr_mutex_t;
+
 #elif defined(MPS_OS_FR) || defined(MPS_OS_LI) || defined(MPS_OS_XC)
 
 #include <pthread.h>
@@ -54,6 +57,8 @@ typedef struct testthr_t {
  * <https://pubs.opengroup.org/onlinepubs/9699919799/basedefs/sys_types.h.html>
  */
 typedef pthread_t testthr_t;
+
+typedef pthread_mutex_t testthr_mutex_t;
 
 #else
 #error "Unknown platform: can't determine a type for testthr_t."
@@ -77,6 +82,27 @@ void testthr_create(testthr_t *thread_o, testthr_routine_t start, void *arg);
  */
 
 void testthr_join(testthr_t *thread, void **result_o);
+
+
+/* testthr_mutex_init -- initialize mutex */
+
+void testthr_mutex_init(testthr_mutex_t *mutex);
+
+
+/* testthr_mutex_finish -- finish mutex */
+
+void testthr_mutex_finish(testthr_mutex_t *mutex);
+
+
+/* testthr_mutex_lock -- lock mutex (blocking if necessary) */
+
+void testthr_mutex_lock(testthr_mutex_t *mutex);
+
+
+/* testthr_mutex_unlock -- unlock mutex */
+
+void testthr_mutex_unlock(testthr_mutex_t *mutex);
+
 
 #endif /* testthr_h */
 

--- a/code/testthrix.c
+++ b/code/testthrix.c
@@ -23,6 +23,34 @@ void testthr_join(testthr_t *thread, void **result_o)
     error("pthread_join failed with result %d (%s)", res, strerror(res));
 }
 
+void testthr_mutex_init(testthr_mutex_t *mutex)
+{
+  int res = pthread_mutex_init(mutex, NULL);
+  if (res != 0)
+    error("pthread_mutex_init failed with result %d (%s)", res, strerror(res));
+}
+
+void testthr_mutex_finish(testthr_mutex_t *mutex)
+{
+  int res = pthread_mutex_destroy(mutex);
+  if (res != 0)
+    error("pthread_mutex_destroy failed with result %d (%s)", res, strerror(res));
+}
+
+void testthr_mutex_lock(testthr_mutex_t *mutex)
+{
+  int res = pthread_mutex_lock(mutex);
+  if (res != 0)
+    error("pthread_mutex_lock failed with result %d (%s)", res, strerror(res));
+}
+
+void testthr_mutex_unlock(testthr_mutex_t *mutex)
+{
+  int res = pthread_mutex_unlock(mutex);
+  if (res != 0)
+    error("pthread_mutex_unlock failed with result %d (%s)", res, strerror(res));
+}
+
 
 /* C. COPYRIGHT AND LICENSE
  *

--- a/code/testthrw3.c
+++ b/code/testthrw3.c
@@ -37,6 +37,26 @@ void testthr_join(testthr_t *thread, void **result_o)
     *result_o = thread->result;
 }
 
+void testthr_mutex_init(testthr_mutex_t *mutex)
+{
+  InitializeCriticalSection(mutex);
+}
+
+void testthr_mutex_finish(testthr_mutex_t *mutex)
+{
+  DeleteCriticalSection(mutex);
+}
+
+void testthr_mutex_lock(testthr_mutex_t *mutex)
+{
+  EnterCriticalSection(mutex);
+}
+
+void testthr_mutex_unlock(testthr_mutex_t *mutex)
+{
+  LeaveCriticalSection(mutex);
+}
+
 
 /* C. COPYRIGHT AND LICENSE
  *

--- a/design/testthr.txt
+++ b/design/testthr.txt
@@ -23,9 +23,9 @@ _`.readership`: Any MPS developer.
 _`.overview`: The MPS is designed to work in a multi-threaded
 environment (see design.mps.thread-safety_) and this needs to be
 tested on all supported platforms. The multi-threaded testing module
-provides an interface for creating and joining threads, so that
-multi-threaded test cases are portable to all platforms on which the
-MPS runs.
+provides interfaces for creating and joining threads, and for locking
+and unlocked mutexes, so that multi-threaded test cases are portable
+to all platforms on which the MPS runs.
 
 .. _design.mps.thread-safety: thread-safety
 
@@ -41,6 +41,10 @@ _`.req.join`: The module must provide an interface for joining a
 running thread: that is, waiting for the thread to finish and
 collecting a result. (Because we want to be able to test that the MPS
 behaves correctly when interacting with a finished thread.)
+
+_`.req.mutex`: The module must provide an interface for mutual
+exclusion. (Because we want to be able to write tests in which
+multiple threads modify the same data structure.)
 
 _`.req.portable`: The module must be easily portable to all the
 platforms on which the MPS runs.
@@ -94,6 +98,29 @@ until the target thread terminates (if necessary), and if ``result_o``
 is non-NULL, update ``*result_o`` with the return value of the
 thread's ``start()`` function.
 
+``typedef testthr_mutex_t``
+
+The type of (non-recursive) mutexes.
+
+``void testthr_mutex_init(testthr_mutex_t *mutex)``
+
+Initialize a mutex. Must be called before any other operation on the
+mutex.
+
+``void testthr_mutex_finish(testthr_mutex_t *mutex)``
+
+Finish a mutex. After this, the mutex must not be used until it has
+been re-initialized.
+
+``void testthr_mutex_lock(testthr_mutex_t *mutex)``
+
+Lock the mutex, blocking the current thread until the lock is
+acquired. The mutex must not be locked by the current thread.
+
+``void testthr_mutex_unlock(testthr_mutex_t *mutex)``
+
+Unlock the mutex.
+
 
 References
 ----------
@@ -108,6 +135,8 @@ Document History
 ----------------
 
 - 2014-10-21 GDR_ Initial draft.
+
+- 2021-01-23 GDR_ Add mutex interface.
 
 .. _GDR: https://www.ravenbrook.com/consultants/gdr/
 


### PR DESCRIPTION
The races arise when multiple threads modify `exactRoots`, or an object pointed to by `exactRoots`, without synchronizing. Prevent races by serializing access to `exactRoots`, and the objects pointed to by `exactRoots`, with a mutex. This doesn't give us the maximum amount of parallelism but it is easy to see that it is correct.

Add mutexes to the test threads interface.

Fixes #59 (Rare failure in amcssth)