### PR TITLE
The MPS no longer supports xci3ll (macOS, i386, Clang/LLVM).

### DIFF
--- a/manual/build.txt
+++ b/manual/build.txt
@@ -147,7 +147,6 @@ Platform     OS          Architecture    Compiler      Makefile
 ``w3i3mv``   Windows     IA-32           Microsoft C   ``w3i3mv.nmk``
 ``w3i6mv``   Windows     x86-64          Microsoft C   ``w3i6mv.nmk``
 ``xca6ll``   macOS       ARM64           Clang         ``mps.xcodeproj``
-``xci3ll``   macOS       IA-32           Clang         ``mps.xcodeproj``
 ``xci6ll``   macOS       x86-64          Clang         ``mps.xcodeproj``
 ==========   =========   =============   ============  =================
 

--- a/manual/source/release.rst
+++ b/manual/source/release.rst
@@ -18,10 +18,12 @@ New features
    * ``lia6ll`` (Linux, ARM64, Clang/LLVM).
    * ``xca6ll`` (macOS, ARM64, Clang/LLVM).
 
-#. The MPS no longer supports building for the xci3ll platform (macOS,
-   IA-32, Clang/LLVM) using Xcode. This is because Xcode 10.0 no
-   longer supports this platform. The platform is still supported via
-   the GNU Make toolchain.
+#. Support removed for platform:
+
+   * ``xci3ll`` (macOS, IA-32, Clang/LLVM).
+
+   Support for this platform was removed in macOS 10.15 (Catalina),
+   making it inconvenient to develop and test.
 
 #. The arena's :term:`spare commit limit` is now expressed as a
    fraction of the :term:`committed <mapped>` memory (rather than a

--- a/manual/source/topic/platform.rst
+++ b/manual/source/topic/platform.rst
@@ -411,7 +411,7 @@ Platform    Status
 ``w3ppmv``  *Not supported*
 ``xca6ll``  Supported
 ``xci3gc``  *Not supported*
-``xci3ll``  Supported
+``xci3ll``  *Not supported*
 ``xci6gc``  *Not supported*
 ``xci6ll``  Supported
 ``xcppgc``  *Not supported*

--- a/readme.txt
+++ b/readme.txt
@@ -72,7 +72,7 @@ The MPS is currently supported for deployment on:
 
 - FreeBSD 7 or later, on IA-32 and x86-64, using GCC or Clang/LLVM;
 
-- macOS 10.4 or later, on IA-32 and x86-64, using Clang/LLVM.
+- macOS 10.4 or later, on x86-64, using Clang/LLVM.
 
 The MPS is highly portable and has run on many other processors and
 operating systems in the past (see `Building the MPS


### PR DESCRIPTION
As of macOS 10.15 (Catalina), this platform is no longer supported by Apple, so it is inconvenient to develop and test. The code is left in place for developers on older versions of macOS.

Fixes #68 (macOS 10.15 (Catalina) no longer builds or runs i386 code).