### PR TITLE
Update links from travis-ci.org to travis-ci.com.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 # .travis.yml -- Travis CI configuration for the MPS
 # $Id$
-# See <http://about.travis-ci.org/docs/user/languages/c/>.
+# See <https://docs.travis-ci.com/user/languages/c/>.
 language: c
 os:
   - linux

--- a/design/guide.developer.txt
+++ b/design/guide.developer.txt
@@ -1,7 +1,7 @@
 .. mode: -*- rst -*-
 
-Review checklist
-================
+New developer guide
+===================
 
 :Tag: guide.developer
 :Status: draft documentation
@@ -48,7 +48,7 @@ References
 .. [APT_2018-09-17]
    "Procedure for new developers";
    Alistair Turnbull; Ravenbrook Limited; 2018-09-17;
-   <https://info.ravenbrook.com/mail/2018/09/17/12-36-45/0/>
+   <https://info.ravenbrook.com/mail/2018/09/17/11-16-41/0/>
 
 
 Document History

--- a/design/tests.txt
+++ b/design/tests.txt
@@ -286,8 +286,8 @@ whenever there is a commit to the `mps GitHub repository`_. See the
 `Ravenbrook/mps`_ project on Travis for a build history.
 
 .. _mps GitHub repository: https://github.com/ravenbrook/mps
-.. _Travis: https://travis-ci.org
-.. _Ravenbrook/mps: https://travis-ci.org/Ravenbrook/mps
+.. _Travis: https://travis-ci.com/
+.. _Ravenbrook/mps: https://travis-ci.com/Ravenbrook/mps
 
 _`.ci.travis.config`: Travis is configured using the .travis.yml file
 at top level of the project.


### PR DESCRIPTION
Fixes #49 (MPS documentation refers to old domain name for Travis)
