### PR TITLE
Fix PROT_EXEC restrictions on Apple Silicon

### DIFF
--- a/code/vmix.c
+++ b/code/vmix.c
@@ -172,8 +172,26 @@ Res VMMap(VM vm, Addr base, Addr limit)
 
   size = AddrOffset(base, limit);
 
+  /**
+   * NOTE: Apple Silicon doesn't have support for specifying
+   * PROT_EXEC along with writable memory.
+   *
+   * We disable this unconditionally on that platform,
+   * pending a more proper solution.
+   *
+   * See apple developer documentation for more details:
+   * https://developer.apple.com/documentation/apple-silicon/porting-just-in-time-compilers-to-apple-silicon
+   *
+   * Also see github issue #75
+   */
+  #if defined(__APPLE__) && defined(__arm64__)
+    #define EXEC_FLAGS 0
+  #else
+    #define EXEC_FLAGS PROT_EXEC
+  #endif
+
   if(mmap((void *)base, (size_t)size,
-          PROT_READ | PROT_WRITE | PROT_EXEC,
+          PROT_READ | PROT_WRITE | EXEC_FLAGS,
           MAP_ANON | MAP_PRIVATE | MAP_FIXED,
           -1, 0)
      == MAP_FAILED) {


### PR DESCRIPTION
Currently, on Apple Silicon chips, calling `mmap(PROT_WRITE | PROT_EXEC)` will fail due to restrictions on marking memory executable & writable at the same time.
    
See apple developer documentation on this new restriction:
https://developer.apple.com/documentation/apple-silicon/porting-just-in-time-compilers-to-apple-silicon
    
This workaround simply stops requesting PROT_EXEC entirely on Apple Silicon. This is not a complete solution, because it does not allow clients to use seamlessly garbage collection to manage their executable memory.
    
However, it does get basic support working. IT works fine as long as you don't use the MPS to directly allocate executable memory.

See also issue #75 (which is not fully resolved by this)
    
Note that any "proper" solution would still require signficant work to interact with the new Apple APIs for JIT.
This means that it is almost certainly going to require some effort on
the part of the client, and possibly new APIs on the part of the MPS.
    
After this commit, the example scheme interpreter builds and runs correctly on my Apple M1 :)

Note the `./configure` script still doesn't work correctly on Apple Silicon, but I figure that's an issue for another PR 😉 