### PR TITLE
Handle errors from mmap and mprotect due to Apple Hardened Runtime.

### DIFF
--- a/code/config.h
+++ b/code/config.h
@@ -714,7 +714,7 @@
  *
  * The MAYBE_HARDENED_RUNTIME macro is true if Apple's "Hardened
  * Runtime" feature may be enabled, and so calls to mmap() and
- * mprotect() with PROT_WRITE | PROT_EXEC will fail with EACCES.
+ * mprotect() with PROT_WRITE | PROT_EXEC may fail with EACCES.
  * See <design/prot#impl.xc.prot.exec> for details.
  */
 #if defined(MPS_OS_XC) && defined(MPS_ARCH_A6)

--- a/code/config.h
+++ b/code/config.h
@@ -710,6 +710,23 @@
 #define WB_DEFER_HIT   1  /* boring scans after barrier hit */
 
 
+/* Apple Hardened Runtime
+ *
+ * .hardened-runtime: On Apple Silicon, applications may be compiled
+ * with Hardened Runtime enabled. These applications have restricted
+ * capabilities: in particular, unless the "Allow Unsigned Executable
+ * Memory Entitlement" is enabled, these applications cannot create
+ * memory that is simultaneously writable and executable. Attempts to
+ * do so using mmap() and mprotect() fail with EACCES.
+ *
+ * See <https://developer.apple.com/documentation/security/hardened_runtime>
+ */
+#if defined(MPS_OS_XC) && defined(MPS_ARCH_A6)
+#define MAYBE_HARDENED_RUNTIME 1
+#else
+#define MAYBE_HARDENED_RUNTIME 0
+#endif
+
 #endif /* config_h */
 
 

--- a/code/config.h
+++ b/code/config.h
@@ -712,14 +712,10 @@
 
 /* Apple Hardened Runtime
  *
- * .hardened-runtime: On Apple Silicon, applications may be compiled
- * with Hardened Runtime enabled. These applications have restricted
- * capabilities: in particular, unless the "Allow Unsigned Executable
- * Memory Entitlement" is enabled, these applications cannot create
- * memory that is simultaneously writable and executable. Attempts to
- * do so using mmap() and mprotect() fail with EACCES.
- *
- * See <https://developer.apple.com/documentation/security/hardened_runtime>
+ * The MAYBE_HARDENED_RUNTIME macro is true if Apple's "Hardened
+ * Runtime" feature may be enabled, and so calls to mmap() and
+ * mprotect() with PROT_WRITE | PROT_EXEC will fail with EACCES.
+ * See <design/prot#impl.xc.prot.exec> for details.
  */
 #if defined(MPS_OS_XC) && defined(MPS_ARCH_A6)
 #define MAYBE_HARDENED_RUNTIME 1

--- a/design/prot.txt
+++ b/design/prot.txt
@@ -51,6 +51,14 @@ the MPS cannot take the correct action: that is, fixing references in
 a read-protected segment, and discarding the remembered set from a
 write-protected segment. See ``TraceSegAccess()``.)
 
+_`.req.prot.exec`: The protection module should allow mutators to
+write machine code into memory managed by the MPS and then execute
+that code, for example, to implement just-in-time translation, or
+other forms of dynamic compilation. Compare
+design.mps.vm.req.prot.exec_.
+
+.. _design.mps.vm.req.prot.exec: vm#.req.prot.exec
+
 
 Design
 ------
@@ -68,6 +76,10 @@ and calling ``ArenaAccess()``.
 
 .. _design.mps.prmc.req.fault.addr: prmc#.req.fault.addr
 .. _design.mps.prmc.req.fault.access: prmc#.req.fault.access
+
+_`.sol.prot.exec`: The protection module makes memory executable
+whenever it is readable by the mutator, if this is supported by the
+platform.
 
 
 Interface
@@ -140,6 +152,39 @@ _`.impl.ix`: POSIX implementation. See design.mps.protix_.
 _`.impl.w3`: Windows implementation.
 
 _`.impl.xc`: macOS implementation.
+
+_`.impl.xc.prot.exec`: The approach in `.sol.prot.exec`_ of always making
+memory executable causes a difficulty on macOS on Apple Silicon. On
+this platform, programs may enable `Hardened Runtime
+<https://developer.apple.com/documentation/security/hardened_runtime>`_.
+This feature rejects attempts to map or protect memory so that it is
+simultaneously writable and executable. Moreoverm the feature is
+enabled by default in recent versions of Xcode, so that if you install
+Xcode and then use it to compile and run the following program, it
+fails with "mmap: Permission denied". ::
+
+    #include <stdio.h>
+    #include <sys/mman.h>
+
+    int main(void)
+    {
+      void *p = mmap(0, 1, PROT_WRITE | PROT_EXEC, MAP_ANONYMOUS | MAP_PRIVATE, -1, 0);
+      if (p == MAP_FAILED) perror("mmap");
+      return 0;
+    }
+
+_`.impl.xc.prot.exec.detect`: The protection module detects Hardened
+Runtime if the operating system is macOS, and the CPU architecture is
+ARM64, a call to ``mprotect()`` fails, the call requested writable and
+executable access, and the error code is ``EACCES``.
+
+_`.impl.xc.prot.exec.retry`: To avoid requiring developers who don't
+need to allocate executable memory to figure out how to disable
+Hardened Runtime, or enable the appropriate entitlement, the
+protection module handles the ``EACCES`` error from ``mprotect()`` in
+the Hardened Runtime case by retrying without the executable flag, and
+setting a global variable to prevent the writable and executable
+combination being attempted again.
 
 
 Document History

--- a/design/prot.txt
+++ b/design/prot.txt
@@ -153,15 +153,14 @@ _`.impl.w3`: Windows implementation.
 
 _`.impl.xc`: macOS implementation.
 
-_`.impl.xc.prot.exec`: The approach in `.sol.prot.exec`_ of always making
-memory executable causes a difficulty on macOS on Apple Silicon. On
-this platform, programs may enable `Hardened Runtime
-<https://developer.apple.com/documentation/security/hardened_runtime>`_.
+_`.impl.xc.prot.exec`: The approach in `.sol.prot.exec`_ of always
+making memory executable causes a difficulty on macOS on Apple
+Silicon. On this platform, programs may enable `Hardened Runtime`_.
 This feature rejects attempts to map or protect memory so that it is
-simultaneously writable and executable. Moreoverm the feature is
-enabled by default in recent versions of Xcode, so that if you install
-Xcode and then use it to compile and run the following program, it
-fails with "mmap: Permission denied". ::
+simultaneously writable and executable. Moreover, the feature is
+enabled by default (as of macOS 13 Ventura), so that if you install
+Xcode and then use it to compile the following program, the executable
+fails when run with "mmap: Permission denied". ::
 
     #include <stdio.h>
     #include <sys/mman.h>
@@ -173,8 +172,10 @@ fails with "mmap: Permission denied". ::
       return 0;
     }
 
+.. _Hardened Runtime: https://developer.apple.com/documentation/security/hardened_runtime
+
 _`.impl.xc.prot.exec.detect`: The protection module detects Hardened
-Runtime if the operating system is macOS, and the CPU architecture is
+Runtime if the operating system is macOS, the CPU architecture is
 ARM64, a call to ``mprotect()`` fails, the call requested writable and
 executable access, and the error code is ``EACCES``.
 
@@ -182,9 +183,9 @@ _`.impl.xc.prot.exec.retry`: To avoid requiring developers who don't
 need to allocate executable memory to figure out how to disable
 Hardened Runtime, or enable the appropriate entitlement, the
 protection module handles the ``EACCES`` error from ``mprotect()`` in
-the Hardened Runtime case by retrying without the executable flag, and
-setting a global variable to prevent the writable and executable
-combination being attempted again.
+the Hardened Runtime case by retrying without the request for the
+memory to be executable, and setting a global variable to prevent the
+writable and executable combination being attempted again.
 
 
 Document History

--- a/design/vm.txt
+++ b/design/vm.txt
@@ -113,6 +113,14 @@ the client program to modify the behaviour of the virtual mapping
 implementation. (This is needed to implement the
 ``MPS_KEY_VMW3_MEM_TOP_DOWN`` keyword argument.)
 
+_`.req.prot.exec`: The virtual mapping module should allow mutators to
+write machine code into memory allocated by the MPS and then execute
+that code, for example, to implement just-in-time translation, or
+other forms of dynamic compilation. Compare
+design.mps.prot.req.prot.exec_.
+
+.. _design.mps.prot.req.prot.exec: prot#.req.prot.exec
+
 
 Design
 ------
@@ -143,6 +151,9 @@ is then passed to ``VMInit()``. The size of the buffer must be
 statically determinable so that the caller can allocate it on the
 stack: it is given by the constant ``VMParamSize``. Since this is
 potentially platform-dependent it is defined in ``config.h``.
+
+_`.sol.prot.exec`: The virtual mapping module maps memory as
+executable, if this is supported by the platform.
 
 
 Interface
@@ -286,6 +297,15 @@ _`.impl.ix.map`: Address space is mapped to main memory by calling
 _`.impl.ix.unmap`: Address space is unmapped from main memory by
 calling |mmap|_, passing ``PROT_NONE`` and ``MAP_ANON | MAP_PRIVATE |
 MAP_FIXED``.
+
+_`.impl.xc.prot.exec`: The approach in `.sol.prot.exec`_ of always
+making memory executable causes a difficulty on macOS on Apple
+Silicon. The virtual mapping module uses the same solution as the
+protection module, that is, detecting Apple Hardened Runtime, and
+dropping the request for executable memory. See
+design.mps.prot.impl.xc.prot.exec_ for details.
+
+.. _design.mps.prot.impl.xc.prot.exec: prot#.impl.xc.prot.exec
 
 
 Windows implementation

--- a/design/vm.txt
+++ b/design/vm.txt
@@ -302,7 +302,7 @@ _`.impl.xc.prot.exec`: The approach in `.sol.prot.exec`_ of always
 making memory executable causes a difficulty on macOS on Apple
 Silicon. The virtual mapping module uses the same solution as the
 protection module, that is, detecting Apple Hardened Runtime, and
-dropping the request for executable memory. See
+retrying without the request for the memory to be executable. See
 design.mps.prot.impl.xc.prot.exec_ for details.
 
 .. _design.mps.prot.impl.xc.prot.exec: prot#.impl.xc.prot.exec

--- a/manual/source/release.rst
+++ b/manual/source/release.rst
@@ -18,6 +18,9 @@ New features
    * ``lia6ll`` (Linux, ARM64, Clang/LLVM).
    * ``xca6ll`` (macOS, ARM64, Clang/LLVM).
 
+   See :ref:`topic-platform-limitations` for limitations in the
+   support for Apple Hardened Runtime on ``xca6ll``.
+
 #. Support removed for platform:
 
    * ``xci3ll`` (macOS, IA-32, Clang/LLVM).

--- a/manual/source/topic/platform.rst
+++ b/manual/source/topic/platform.rst
@@ -416,3 +416,39 @@ Platform    Status
 ``xci6ll``  Supported
 ``xcppgc``  *Not supported*
 ==========  =======================
+
+
+.. index::
+   pair: platform; limitations
+   single: Hardened Runtime
+
+.. _topic-platform-limitations:
+
+Platform limitations
+--------------------
+
+This section documents limitations that affect individual platforms.
+
+``xca6ll``
+
+   On macOS on Apple Silicon, programs may enable `Hardened Runtime`_.
+   This feature rejects attempts to map or protect memory so that it
+   is simultaneously writable and executable. Therefore, when Hardened
+   Runtime is enabled, memory managed by the MPS is not executable.
+
+   .. _Hardened Runtime: https://developer.apple.com/documentation/security/hardened_runtime
+
+   If your program needs to write executable code into memory managed
+   by the MPS (for example, it uses just-in-time translation or
+   dynamic compilation), then you must either disable Hardened
+   Runtime, or configure the `Allow Unsigned Executable Memory
+   Entitlement`_.
+
+   .. _Allow Unsigned Executable Memory Entitlement: https://developer.apple.com/documentation/bundleresources/entitlements/com_apple_security_cs_allow-unsigned-executable-memory
+
+   Note that the MPS has no support for Apple's :c:macro:`MAP_JIT`
+   flag. If your application is using the `Allow Execution of
+   JIT-compiled Code Entitlement`_ and needs support for this flag,
+   please :ref:`contact us <contact>`.
+
+   .. _Allow Execution of JIT-compiled Code Entitlement: https://developer.apple.com/documentation/bundleresources/entitlements/com_apple_security_cs_allow-jit


### PR DESCRIPTION
On Apple Silicon, when [Hardened Runtime](https://developer.apple.com/documentation/security/hardened_runtime) is in force and the application lacks the "[Allow Unsigned Executable Memory Entitlement](https://developer.apple.com/documentation/bundleresources/entitlements/com_apple_security_cs_allow-unsigned-executable-memory)", `mmap` and `mprotect` return `EACCES` when an attempt is made to create or modify memory so that it is simultaneously writable and executable.

This commit handles these cases by retrying the operation without the `PROT_EXEC` flag, and setting global variables so that future operations omit the flag.

Work towards #75 (Issue with Apple silicon write-xor-execute memory requirements)

Note that this doesn't completely address #75 because there is no provision for `MAP_JIT`. However, in the absence of a clear customer requirement it's difficult for me to pick a good solution. This commit is a self-contained change that allows developers to work with the MPS on Apple Silicon without having to configure the Allow Unsigned Executable Memory Entitlement.