### PR TITLE
Fix up array overrun warnings on gcc 11.3.0

### DIFF
--- a/code/poolams.c
+++ b/code/poolams.c
@@ -747,7 +747,7 @@ static void AMSSegsDestroy(AMS ams)
 
 /* AMSVarargs -- decode obsolete varargs */
 
-static void AMSVarargs(ArgStruct args[MPS_ARGS_MAX], va_list varargs)
+static void AMSVarargs(ArgStruct args[MPS_ARGS_MAX - 1], va_list varargs)
 {
   args[0].key = MPS_KEY_FORMAT;
   args[0].val.format = va_arg(varargs, Format);
@@ -756,6 +756,7 @@ static void AMSVarargs(ArgStruct args[MPS_ARGS_MAX], va_list varargs)
   args[2].key = MPS_KEY_AMS_SUPPORT_AMBIGUOUS;
   args[2].val.b = va_arg(varargs, Bool);
   args[3].key = MPS_KEY_ARGS_END;
+  AVER(MPS_ARGS_MAX - 1 > 3);
   AVERT(ArgList, args);
 }
 

--- a/code/poolmvff.c
+++ b/code/poolmvff.c
@@ -364,7 +364,7 @@ static Res MVFFBufferFill(Addr *baseReturn, Addr *limitReturn,
 
 /* MVFFVarargs -- decode obsolete varargs */
 
-static void MVFFVarargs(ArgStruct args[MPS_ARGS_MAX], va_list varargs)
+static void MVFFVarargs(ArgStruct args[MPS_ARGS_MAX - 1], va_list varargs)
 {
   args[0].key = MPS_KEY_EXTEND_BY;
   args[0].val.size = va_arg(varargs, Size);
@@ -379,6 +379,7 @@ static void MVFFVarargs(ArgStruct args[MPS_ARGS_MAX], va_list varargs)
   args[5].key = MPS_KEY_MVFF_FIRST_FIT;
   args[5].val.b = va_arg(varargs, Bool);
   args[6].key = MPS_KEY_ARGS_END;
+  AVER(MPS_ARGS_MAX - 1 > 6);
   AVERT(ArgList, args);
 }
 


### PR DESCRIPTION
Intended to resolve #114.

Specifies the shortened array in function prototypes to express intentions.