### PR TITLE
Fix and update the pull request merge procedure

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,11 @@
 # .travis.yml -- Travis CI configuration for the MPS
 # $Id$
+
+# Some branches don't need builds.  Add them here to avoid using build
+# resources and unnecessary build messages.  See
+# <https://docs.travis-ci.com/user/conditions-v1>.
+if: NOT branch IN (branch/2023-01-07/pull-request-merge-procedure)
+
 # See <https://docs.travis-ci.com/user/languages/c/>.
 language: c
 os:

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,8 +3,10 @@
 
 # Some branches don't need builds.  Add them here to avoid using build
 # resources and unnecessary build messages.  See
-# <https://docs.travis-ci.com/user/conditions-v1>.
-if: NOT branch IN (branch/2023-01-07/pull-request-merge-procedure)
+# <https://docs.travis-ci.com/user/customizing-the-build/#safelisting-or-blocklisting-branches>.
+branches:
+  except:
+    - branch/2023-01-07/pull-request-merge-procedure
 
 # See <https://docs.travis-ci.com/user/languages/c/>.
 language: c

--- a/procedure/pull-request-merge.rst
+++ b/procedure/pull-request-merge.rst
@@ -26,9 +26,9 @@ MPS Help" [GDR_2020-09-03]_ .
 The document is still draft.  Some of the questions that need
 resolving are noted in square brackets.
 
-Ravenbrook is currently (2023-01) migrating the MPS project to git
-(and GitHub) and this is likely to modify this procedure.  [Insert
-reference to that project.  RB 2023-01-07]
+Ravenbrook is currently (2023-01) `migrating the MPS project to git
+(and GitHub) <https://github.com/Ravenbrook/mps/issues/98>`_ and this
+is likely to modify and simplify this procedure.
 
 
 2. Pre-merge checklist

--- a/procedure/pull-request-merge.rst
+++ b/procedure/pull-request-merge.rst
@@ -417,6 +417,7 @@ B. Document History
 
 ==========  =====  ==================================================
 2023-01-07  RB_    Created.
+2023-01-13  RB_    Updates after first attempt at execution.
 ==========  =====  ==================================================
 
 .. _RB: mailto:rb@ravenbrook.com

--- a/procedure/pull-request-merge.rst
+++ b/procedure/pull-request-merge.rst
@@ -137,7 +137,7 @@ These steps will only rarely need repeating.
 #. Add the Git Fusion mps-public repo, which is the interface to
    Ravenbrook's Perforce. ::
 
-     git remote add ravenbrook ssh://git@perforce.ravenbrook.com:1622/mps-public
+     git remote add perforce ssh://git@perforce.ravenbrook.com:1622/mps-public
 
 
 4. Merging a development branch
@@ -168,7 +168,7 @@ These steps will only rarely need repeating.
 
 4. Merge master with the branch::
 
-     git pull ravenbrook master:master
+     git pull perforce master:master
      git checkout branch/2023-01-06/speed-hax
      git merge master
 
@@ -216,13 +216,13 @@ These steps will only rarely need repeating.
 
 8. Push master and the branch to Perforce via Git Fusion::
 
-     git push ravenbrook master branch/2023-01-06/speed-hax
+     git push perforce master branch/2023-01-06/speed-hax
 
    If this fails because someone has submitted changes to the master
    codeline since you started.  Replace your master with those changes
    and go back to merging (step 4). ::
 
-     git pull --force ravenbrook master:master
+     git pull --force perforce master:master
 
 9. If and *only if* the Perforce push (step 8) succeeds, you can
    also push to GitHub::

--- a/procedure/pull-request-merge.rst
+++ b/procedure/pull-request-merge.rst
@@ -38,7 +38,7 @@ MPS Help" [GDR_2020-09-03]_ .
 The answers to these questions should be "yes".  If the answer to a
 question isn't "yes", record that, and why, in response to the pull
 request (and maybe suggest what to do about it).  When you finish the
-checklist, decide whether to continue with the procedure.
+checklist, decide whether to start `the merging procedure`_.
 
 #. Is there a permanent visible document (issue, job), referenced by
    the branch, recording the problem that is solved by the changes in
@@ -148,8 +148,8 @@ These steps will only rarely need repeating.
    record.
 
 #. Clone the Ravenbrook MPS GitHub repository and name the remote
-   "github".  This will give you access to Travis CI to build and test
-   the merge.  (If you're an MPS developer you can use your existing
+   "github".  This will give you access to CI to build and test the
+   merge.  (If you're an MPS developer you can use your existing
    repo.)  ::
 
      git clone -o github git@github.com:Ravenbrook/mps.git
@@ -380,6 +380,14 @@ According to `GitHub's "About pull request merges"
   Rather than build the commits that have been pushed to the branch
   the pull request is from, we build the merge between the source
   branch and the upstream branch.
+
+When we use a GitHub CI on pull requests, that's also run on the merge
+results.  As `GitHub's pull request event documentation
+<https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#pull_request>`_
+says:
+
+  GITHUB_SHA for this event is the last merge commit of the pull
+  request merge branch.
 
 So, `once Git becomes the home
 <https://github.com/Ravenbrook/mps/issues/98>`_ we will be able to use

--- a/procedure/pull-request-merge.rst
+++ b/procedure/pull-request-merge.rst
@@ -140,8 +140,8 @@ These steps will only rarely need repeating.
      git remote add perforce ssh://git@perforce.ravenbrook.com:1622/mps-public
 
 
-4. Merging a development branch
--------------------------------
+4. Merging procedure
+--------------------
 
 1. `Fetch the pull request branch`_ to a local branch using the MPS
    durable branch naming convention, "branch/DATE/TOPIC", e.g. ::

--- a/procedure/pull-request-merge.rst
+++ b/procedure/pull-request-merge.rst
@@ -204,7 +204,7 @@ These steps will only rarely need repeating.
    Git Fusion mapping, and so the result is the same as if it had come
    in via Perforce.
 
-7. Replace the master with your branch, effecting the merge::
+7. Replace the master with your merged branch::
 
      git checkout master
      git merge --ff-only branch/2023-01-06/speed-hax

--- a/procedure/pull-request-merge.rst
+++ b/procedure/pull-request-merge.rst
@@ -166,7 +166,7 @@ These steps will only rarely need repeating.
 --------------------
 
 1. `Fetch the pull request branch`_ to a local branch using the MPS
-   durable branch naming convention, "branch/DATE/TOPIC".
+   `durable branch naming convention`_, "branch/DATE/TOPIC".
 
    If the branch already has a conventional name, and it's in the
    `Ravenbrook MPS repo on GitHub`_ then fetch it with the existing
@@ -319,6 +319,11 @@ These steps will only rarely need repeating.
 
 .. _Fetch the pull request branch: https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/reviewing-changes-in-pull-requests/checking-out-pull-requests-locally#modifying-an-inactive-pull-request-locally
 
+9. Eyeball the pull request and related issues on GitHub to make sure
+   the merge was recorded correctly.  Check that any issues *not
+   completely resolved* by the merge were not closed.  Re-open them if
+   necessary.
+
 
 6. Rationale
 ------------
@@ -405,6 +410,8 @@ section 3, the pre-merge checklist.  We may be able to incorporate the
 checklist into GitHub's interface using a `pull request template
 <https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/creating-a-pull-request-template-for-your-repository>`_.
 
+
+.. _durable branch naming convention:
 
 6.3. Why the "durable" branch names?
 ------------------------------------

--- a/procedure/pull-request-merge.rst
+++ b/procedure/pull-request-merge.rst
@@ -54,7 +54,8 @@ you should probably read section "`6. Rationale`_".
 The answers to these questions should be "yes".  If the answer to a
 question isn't "yes", record that, and why, in response to the pull
 request (and maybe suggest what to do about it).  When you finish the
-checklist, decide whether to start `the merging procedure`_.
+checklist, decide whether to start `the merging procedure`_ by
+considering `2. Purpose`_.
 
 #. Is there a permanent visible document (issue, job), referenced by
    the branch, recording the problem that is solved by the changes in

--- a/procedure/pull-request-merge.rst
+++ b/procedure/pull-request-merge.rst
@@ -159,7 +159,9 @@ These steps will only rarely need repeating.
 
    If the pull request is from the `Ravenbrook MPS repo on GitHub`_,
    and its branch already has a conventional name, then use the
-   existing name.
+   existing name, e.g. ::
+
+     git fetch github branch/2023-01-06/speed-hax:branch/2023-01-06/speed-hax
 
    If the branch to be merged is in a third-party repo, such as a fork
    not on GitHub, you can fetch it using a remote, e.g.::

--- a/procedure/pull-request-merge.rst
+++ b/procedure/pull-request-merge.rst
@@ -64,8 +64,8 @@ checklist, decide whether to continue with the procedure.
    the material to which they are contributing.  (See `"Licensing" in
    "Contributing to the MPS" <../contributing.rst#licensing>`_.)
 
-   If they have, talk to them or get someone to talk to them about the
-   matter.  Do not proceed.
+   If they have expressed a variation, talk to them or get someone to
+   talk to them about the matter.  *Do not proceed with merging*.
 
 #. Does the branch build and pass tests on all `target platforms
    <../readme.txt>`_?

--- a/procedure/pull-request-merge.rst
+++ b/procedure/pull-request-merge.rst
@@ -246,38 +246,74 @@ This section explains why the procedure is like it is.  It's intended
 for people who want to vary the procedure on the fly, or make
 permanent changes to it.  In the latter case, update this section!
 
-5.1. Why not press the GitHub merge button?
+
+5.1. Why not rebase or squash merge?
+------------------------------------
+
+We would like to avoid rewriting history and the destruction of
+information on the grounds that it destroys information that could be
+important to the engineering of the MPS, such as tracking down
+defects, comprehending the intention of changes.  So want to
+discourage rebasing or squashing.
+
+We want to avoid fast-forwards of master.  A fast-forward means there
+is no commit that records the fact that there has been a merge, by
+whom, from where, for what purpose, etc.  It discards that
+information.  Therefore we want to discourage fast-forwards of master
+in favour of merges.  (Annoyingly, GitHub only provides `branch
+protection that enforces the opposite
+<https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/defining-the-mergeability-of-pull-requests/about-protected-branches#require-linear-history>`_!)
+See also `5.3. Why the "durable" branch names?`_.
+
+We also want to avoid `squash merges
+<https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/incorporating-changes-from-a-pull-request/about-pull-request-merges#squash-and-merge-your-commits>`_.
+A squash merge compresses development history into a single commit,
+destroying the record of what happened during development and the
+connection to the branch.
+
+The main motivation for fast-forwards and squashes appears to be to
+simplify the branching history so that it's easier to understand.
+Better tools and interfaces are no doubt required for analysing Git
+history.  These will emerge.  And they will be able to analyse the
+history that we are creating today.
+
+There is also a strong tendency among developers to "correct" mistakes
+and edit history to reflect "what should have happened" or "what I
+meant to do", treating history like code.  But it's the function of
+version control to protect software against well-intentioned mistakes.
+Git is bad at remembering changes to history (it has no meta-history)
+and so we should not edit it.
+
+
+5.2. Why not press the GitHub merge button?
 -------------------------------------------
 
-GitHub provides a merge button on pull requests.  According to
-[Chaser324_2017]_ it only works for branches that can fast-forward
-master, and also only creates fast-forwards.
+We cannot use the GitHub pull request merge button because it would
+put the GitHub master branch out of sync with (ahead of) Perforce.
+Currently, Perforce is the authoritative home of the MPS, and the Git
+repository is a mirror.
 
-[This might not be true.  See `About merge methods on GitHub
-<https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/configuring-pull-request-merges/about-merge-methods-on-github>`_.
-RB 2023-01-09]
+According to `GitHub's "About pull request merges"
+<https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/incorporating-changes-from-a-pull-request/about-pull-request-merges>`_:
 
-There are two reasons this is undesirable.
+  When you click the default Merge pull request option on a pull
+  request on GitHub.com, all commits from the feature branch are added
+  to the base branch in a merge commit.
 
-Firstly, it's quite likely that a pull request has a branch that isn't
-at the tip of master and can't be fast-forwarded.  It's possible to
-rebase such branches only if Perforce has never seen them, because
-Perforce does not permit branch history to be rewritten.  We could
-have a more complicated procedure involving making a new rebased
-branch, but the result would be less good.
+`Travis CI builds and tests this merge in advance <https://docs.travis-ci.com/user/pull-requests/#how-pull-requests-are-built>`_:
 
-Secondly, we would like to avoid rewriting history and the destruction
-of information on the grounds that it is bad software engineering, and
-so want to discourage rebasing.
+  Rather than build the commits that have been pushed to the branch
+  the pull request is from, we build the merge between the source
+  branch and the upstream branch.
 
-And it's for this reason we also want to avoid fast-forwards of
-master.  A fast-forward means there is no commit that records the fact
-that there has been a merge, by whom, from where, etc.  It discards
-that information.  Therefore we want to discourage fast-forwards of
-master in favour of merges.
+So, `once Git becomes the home
+<https://github.com/Ravenbrook/mps/issues/98>`_ we will be able to use
+the button to to replace sections 3 and 4, the procedure, but not
+section 2, the pre-merge checklist.  We may be able to incorporate the
+checklist into GitHub's interface.
 
 
-5.2. Why the "durable" branch names?
+5.3. Why the "durable" branch names?
 ------------------------------------
 
 It's common in Git culture to delete branches once they've been
@@ -311,10 +347,6 @@ A. References
 .. [Ardalis_2017] "Why Delete Old Git Branches?"; Steve Ardalis;
 		  2017-07-20;
 		  <https://ardalis.com/why-delete-old-git-branches/>.
-
-.. [Chaser324_2017] "GitHub Standard Fork & Pull Request Workflow";
-                    Chase Pettit; 2017;
-                    <https://gist.github.com/Chaser324/ce0505fbed06b947d962#automatically-merging-a-pull-request>.
 
 .. [GDR_2020-09-03] "Re: Possible MPS help"; Gareth Rees; 2020-09-03;
 		    <https://info.ravenbrook.com/mail/2020/09/03/13-02-35/0/>.

--- a/procedure/pull-request-merge.rst
+++ b/procedure/pull-request-merge.rst
@@ -192,7 +192,7 @@ These steps will only rarely need repeating.
 6. Push the branch to the Ravenbrook MPS GitHub repository to trigger
    building and testing on all target platforms using Travis CI. ::
 
-     git push github branch/2023-01-06/speed-hax:branch/2023-01-06/speed-hax
+     git push github branch/2023-01-06/speed-hax
 
    You will need to wait for results from Travis CI.  [Add details of
    how to see them.  RB 2023-07-01]

--- a/procedure/pull-request-merge.rst
+++ b/procedure/pull-request-merge.rst
@@ -189,9 +189,9 @@ These steps will only rarely need repeating.
 
      git pull --ff-only perforce master
 
-   If this doesn't succeed, then GitHub's master and Perforce's master
-   are in out of sync, and this procedure fails.  [It may be possible
-   to quickly fix that here and now and continue.  RB 2023-01-12]
+   If you get an error, then GitHub's master and Perforce's master are
+   in out of sync, and this procedure fails.  [It may be possible to
+   quickly fix that here and now and continue.  RB 2023-01-12]
 
 4. Merge the branch in to your local master::
 

--- a/procedure/pull-request-merge.rst
+++ b/procedure/pull-request-merge.rst
@@ -92,6 +92,8 @@ checklist, decide whether to start `the merging procedure`_.
    talk to them about the matter.  *Do not start the merging
    procedure*.
 
+.. _checked pull request build results from CI:
+
 #. Does the branch, and its merge, build and pass tests?
 
    CI should have run builds of both the branch, and a *trial merge*
@@ -240,11 +242,11 @@ These steps will only rarely need repeating.
    branch.  If you still can't resolve conflicts, this procedure
    fails.
 
-5. If either
+5. Maybe build and test locally.  If either
 
    - the merge was non-trivial
    - there has been any rebasing (see step 7)
-   - you haven't checked pull request build results from CI
+   - you haven't `checked pull request build results from CI`_
 
    then build and test the merge result locally if possible.  For
    example::
@@ -259,11 +261,11 @@ These steps will only rarely need repeating.
    fails, and you need to go back to the source of the branch,
    e.g. the pull request and its original author.  Something's wrong!
 
-6. If either
+6. Maybe build and test using CI.  As with step 5, if either
 
    - the merge was non-trivial
    - there has been any rebasing (see step 7)
-   - you haven't checked pull request build results from CI
+   - you haven't `checked pull request build results from CI`_
 
    then push the merge to a fresh branch in the `Ravenbrook MPS repo
    on GitHub`_ to trigger CI to build and testing on all target

--- a/procedure/pull-request-merge.rst
+++ b/procedure/pull-request-merge.rst
@@ -237,8 +237,19 @@ These steps will only rarely need repeating.
      git pull --ff-only perforce master
 
    If you get an error, then GitHub's master and Perforce's master are
-   in out of sync, and this procedure fails.  [It may be possible to
-   quickly fix that here and now and continue.  RB 2023-01-12]
+   in out of sync, and this procedure fails.
+
+   Ensure your local master is not ahead of Perforce::
+
+     git push --dry-run perforce
+
+   If this shows anything other than "Everything up-to-date." then
+   GitHub's master and Perforce's master are in out of sync, and this
+   procedure fails.
+
+   [It may be possible to fix that here and now and continue.  That's
+   a subject for a whole nother procedure that we don't currently
+   have.  RB 2023-01-12]
 
 4. Merge the branch in to your local master::
 

--- a/procedure/pull-request-merge.rst
+++ b/procedure/pull-request-merge.rst
@@ -146,7 +146,11 @@ These steps will only rarely need repeating.
 1. `Fetch the pull request branch`_ to a local branch using the MPS
    durable branch naming convention, "branch/DATE/TOPIC", e.g. ::
 
-     git fetch github pull/93/head:branch/2022-12-23/hardened-runtime
+     git fetch github pull/93/head:branch/2023-01-06/speed-hax
+
+   If the pull request is from the Ravenbrook MPS repo on GitHub then
+   its branch may already have a conventional name.  Use the existing
+   name.
 
    If the branch to be merged is in a third-party repo, such as a fork
    not on GitHub, you can fetch it usina a remote, e.g.::

--- a/procedure/pull-request-merge.rst
+++ b/procedure/pull-request-merge.rst
@@ -35,6 +35,11 @@ MPS Help" [GDR_2020-09-03]_ .
 2. Pre-merge checklist
 ----------------------
 
+The answers to these questions should be "yes".  If the answer to a
+question isn't "yes", record that, and why, in response to the pull
+request (and maybe suggest what to do about it).  When you finish the
+checklist, decide whether to continue with the procedure.
+
 #. Is there a permanent visible document (issue, job), referenced by
    the branch, recording the problem that is solved by the changes in
    the branch?

--- a/procedure/pull-request-merge.rst
+++ b/procedure/pull-request-merge.rst
@@ -72,7 +72,7 @@ considering `2. Purpose`_.
 #. If the changes are significant and user-visible, is there an update
    to the release notes (``manual/source/release.rst``)?
 
-#. Has there been a code review?
+#. Has there been a code review, and only review edits since?
 
 #. Is the merge approved by an approving review?
 

--- a/procedure/pull-request-merge.rst
+++ b/procedure/pull-request-merge.rst
@@ -308,7 +308,7 @@ working repo before that point.
    on GitHub`_.  This should trigger CI to build and testing on all
    target platforms. ::
 
-     git push github merge/2023-01-06/speed-hax
+     git push github HEAD:merge/2023-01-06/speed-hax
 
    You will need to wait for results from CI.  Look for a build
    results in the `Travis CI build history for the repo`_ and in the

--- a/procedure/pull-request-merge.rst
+++ b/procedure/pull-request-merge.rst
@@ -62,12 +62,22 @@ you should probably read section "`6. Rationale`_".
 3. Pre-merge checklist
 ----------------------
 
-The answers to these questions should be "yes".  If the answer to a
-question isn't "yes", record that, and why, in response to the pull
-request (and maybe suggest what to do about it).  Include a permalink
-to the revision of this procedure that you are following.  When you
-finish the checklist, decide whether to start `the merging procedure`_
-by considering `2. Purpose`_.
+Start by making a record for the merge.  Make a comment on the pull
+request with a permalink to the procedure you're following (this one),
+like::
+
+  Executing [proc.merge.pull-request](https://github.com/Ravenbrook/mps/blob/973fc087c9abff01a957b85bd17c4a2be434ae73/procedure/pull-request-merge.rst)
+
+The answers to the checklist questions should be "yes".  If the answer
+to a question isn't "yes", record that, and why (and maybe suggest
+what to do about it).  For example::
+
+  2. An automated test case isn't feasible as it would mean
+     introducing broken shell scripts to GitHub and watching for CI
+     errors.
+
+When you finish the checklist, decide whether to start
+`the merging procedure`_ by considering `2. Purpose`_.
 
 #. Is there a permanent visible document (issue, job), referenced by
    the branch, recording the problem that is solved by the changes in
@@ -506,6 +516,7 @@ B. Document History
 2023-01-14  RB_    Updates after `second (successful) execution`_.
 2023-01-23  RB_    Adding measurements.
 2023-01-25  RB_    Responding to mini-review_.
+2023-01-31  RB_    Adding instructions for recording the merge.
 ==========  =====  ==================================================
 
 .. _RB: mailto:rb@ravenbrook.com

--- a/procedure/pull-request-merge.rst
+++ b/procedure/pull-request-merge.rst
@@ -337,6 +337,14 @@ repository are intended to last forever.  That is why they have
 This policy has persisted over decades through more than one SCM
 system, and will persist when Git has been replaced by the next one.
 
+Note: `GitHub branch protection rules`_ are `enabled
+<https://github.com/Ravenbrook/mps/settings/branches>`_ on the
+`Ravenbrook MPS repo on GitHub`_ and should prevent deletion.
+
+.. _Ravenbrook MPS repo on GitHub: https://github.com/Ravenbrook/mps
+
+.. _GitHub branch protection rules: https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/defining-the-mergeability-of-pull-requests/about-protected-branches#require-linear-history
+
 
 A. References
 -------------

--- a/procedure/pull-request-merge.rst
+++ b/procedure/pull-request-merge.rst
@@ -2,6 +2,7 @@
 Memory Pool System pull request merge procedure
 ===============================================
 
+:tag: proc.merge.pull-request
 :author: Richard Brooksby
 :organization: Ravenbrook Limited
 :date: 2023-01-07

--- a/procedure/pull-request-merge.rst
+++ b/procedure/pull-request-merge.rst
@@ -32,7 +32,23 @@ containing the working steps for git / GitHub merges, "Re: Possible
 MPS Help" [GDR_2020-09-03]_ .
 
 
-2. Pre-merge checklist
+2. Purpose
+----------
+
+The purpose of this procedure is:
+
+1. get required changes in to the MPS
+
+2. protect the MPS from introduction of defects
+
+3. maintain and protect the permanent record of the MPS in Perforce
+   and Git, so that defects can be discovered, fixed, and prevented
+
+As with any procedure, you can vary this one to meet this purpose, but
+you should probably read section "`6. Rationale`_".
+
+
+3. Pre-merge checklist
 ----------------------
 
 The answers to these questions should be "yes".  If the answer to a
@@ -143,7 +159,7 @@ checklist, decide whether to start `the merging procedure`_.
 .. _GitHub workflows for the repo: https://github.com/Ravenbrook/mps/actions
 
 
-3. Prerequisite steps
+4. Prerequisite steps
 ---------------------
 
 These steps will only rarely need repeating.
@@ -176,7 +192,7 @@ These steps will only rarely need repeating.
 
 .. _the merging procedure:
 
-4. Merging procedure
+5. Merging procedure
 --------------------
 
 1. `Fetch the pull request branch`_ to a local branch using the MPS
@@ -322,15 +338,18 @@ These steps will only rarely need repeating.
 .. _Fetch the pull request branch: https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/reviewing-changes-in-pull-requests/checking-out-pull-requests-locally#modifying-an-inactive-pull-request-locally
 
 
-5. Rationale
+6. Rationale
 ------------
 
 This section explains why the procedure is like it is.  It's intended
 for people who want to vary the procedure on the fly, or make
 permanent changes to it.  In the latter case, update this section!
 
+[This section should argue the case in terms of section "`2. Purpose`_".
+RB 2023-01-14]
 
-5.1. Why not rebase or squash merge?
+
+6.1. Why not rebase or squash merge?
 ------------------------------------
 
 We would like to avoid rewriting history and the destruction of
@@ -346,7 +365,7 @@ information.  Therefore we want to discourage fast-forwards of master
 in favour of merges.  (Annoyingly, GitHub only provides `branch
 protection that enforces the opposite
 <https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/defining-the-mergeability-of-pull-requests/about-protected-branches#require-linear-history>`_!)
-See also `5.3. Why the "durable" branch names?`_.
+See also `6.3. Why the "durable" branch names?`_.
 
 We also want to avoid `squash merges
 <https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/incorporating-changes-from-a-pull-request/about-pull-request-merges#squash-and-merge-your-commits>`_.
@@ -368,7 +387,7 @@ Git is bad at remembering changes to history (it has no meta-history)
 and so we should not edit it.
 
 
-5.2. Why not press the GitHub merge button?
+6.2. Why not press the GitHub merge button?
 -------------------------------------------
 
 We cannot use the GitHub pull request merge button because it would
@@ -399,13 +418,13 @@ says:
 
 So, `once Git becomes the home
 <https://github.com/Ravenbrook/mps/issues/98>`_ we will be able to use
-the button to to replace sections 3 and 4, the procedure, but not
-section 2, the pre-merge checklist.  We may be able to incorporate the
+the button to to replace sections 4 and 5, the procedure, but not
+section 3, the pre-merge checklist.  We may be able to incorporate the
 checklist into GitHub's interface using a `pull request template
 <https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/creating-a-pull-request-template-for-your-repository>`_.
 
 
-5.3. Why the "durable" branch names?
+6.3. Why the "durable" branch names?
 ------------------------------------
 
 It's common in Git culture to delete branches once they've been

--- a/procedure/pull-request-merge.rst
+++ b/procedure/pull-request-merge.rst
@@ -104,6 +104,7 @@ is likely to modify and simplify this procedure.
 
    If you have no build and test results for the merge, then you can
    still execute this procedure if:
+
    #. you believe there are only merge conflicts,
    #. you're willing to try to resolve those conflicts, and
    #. you're prepared to test on all target platforms.

--- a/procedure/pull-request-merge.rst
+++ b/procedure/pull-request-merge.rst
@@ -197,7 +197,8 @@ These steps will only rarely need repeating.
 
      git merge --no-ff branch/2023-01-06/speed-hax
 
-   Edit the commit message to say something like::
+   Edit the commit message to link it to *why* you are merging.  Say
+   something like::
 
      Merging branch/2023-01-06/speed-hax for GitHub pull request 93
      <https://github.com/Ravenbrook/mps/pull/93>.

--- a/procedure/pull-request-merge.rst
+++ b/procedure/pull-request-merge.rst
@@ -104,9 +104,9 @@ reference to that project.  RB 2023-01-07]
 
    If you have no build and test results for the merge, then you can
    still execute this procedure if:
-   # you believe there are only merge conflicts,
-   # you're willing to try to resolve those conflicts, and
-   # you're prepared to test on all target platforms.
+   #. you believe there are only merge conflicts,
+   #. you're willing to try to resolve those conflicts, and
+   #. you're prepared to test on all target platforms.
 
 [Checklist items for Customer-specific branches from branch-merge.rst
 omitted for now.  RB 2023-01-07]

--- a/procedure/pull-request-merge.rst
+++ b/procedure/pull-request-merge.rst
@@ -17,6 +17,16 @@ Memory Pool System pull request merge procedure
 This document contains a procedure for merging a branch received via a
 GitHub "pull request".
 
+Time to execute:
+
+- first time: 2 hours
+- second time: 30 minutes
+- with practice: < 10 minutes
+
+these are measurements_ taken during simple merges that passed automated tests.
+
+.. _measurements: https://github.com/Ravenbrook/mps/pull/97#issuecomment-1381771818
+
 Ravenbrook is currently (2023-01) `migrating the MPS project to git
 (and GitHub) <https://github.com/Ravenbrook/mps/issues/98>`_ and that
 will greatly simplify this procedure.
@@ -474,6 +484,7 @@ B. Document History
 2023-01-07  RB_    Created.
 2023-01-13  RB_    Updates after `first attempt at execution`_.
 2023-01-14  RB_    Updates after `second (successful) execution`_.
+2023-01-23  RB_    Adding measurements.
 ==========  =====  ==================================================
 
 .. _RB: mailto:rb@ravenbrook.com

--- a/procedure/pull-request-merge.rst
+++ b/procedure/pull-request-merge.rst
@@ -92,63 +92,32 @@ checklist, decide whether to start `the merging procedure`_.
    talk to them about the matter.  *Do not start the merging
    procedure*.
 
-#. Does the branch build and pass tests on all `target platforms
-   <../readme.txt>`_?
+#. Does the branch, and its merge, build and pass tests?
 
-   If the branch is in the `Ravenbrook MPS repo on GitHub`_ then CI
-   should have run builds of the branch.  To check, either:
+   CI should have run builds of both the branch, and a *trial merge*
+   of the pull request with master.  Success by CI is a strong
+   indication that `the merging procedure`_ will be quick and
+   successful.
 
-   - Look for build results for the branch (not the pull request) in
-     the "checks" section of the pull request on GitHub.  Expand "Show
-     all checks", and look for build success messages *for the
-     branch*.
+   Look for build results in the pull request on GitHub.  Expand "Show
+   all checks", and look for build success messages for both the
+   branch and for the pull request (the trial merge).  If these
+   results are missing, inform sysadmins that CI isn't functioning.
 
-   - Look for a the most recent build of the branch in the `Travis CI
-     build history for the repo`_.
+   You can also look for a build results in the `Travis CI build
+   history for the repo`_ and in the `GitHub workflows for the repo`_.
 
-   - Look for the most recent build of the branch in the `GitHub
-     workflows for the repo`_.
+   If there is a failed build *of the branch* you should not execute
+   `the merging procedure`_, but talk to the contributor about fixing
+   the branch.
 
-   If there is a failed build you should not execute `the merging
-   procedure`_, but talk to the contributor about fixing the branch.
-
-   If the branch is in the `Ravenbrook MPS repo on GitHub`_ and builds
-   are missing from the "checks" section of pull request, inform
-   sysadmins that CI isn't functioning.
-
-   If you have no build and test results, you can still execute `the
-   merging procedure`_, with caution.
-
-#. Does the branch merge cleanly in to master and pass tests on all
-   target platforms?
-
-   CI should have run builds of the pull request (i.e. `of a merge
-   with master
-   <https://docs.travis-ci.com/user/pull-requests/#how-pull-requests-are-built>`_).
-   To check, either:
-
-   - Look for build results for the pull request (not the branch) in
-     the pull request on GitHub.  Expand "Show all checks", and look
-     for build success messages *for the pull request*.
-
-   - Look for a successful build of the pull request in the `Travis CI
-     build history for the repo`_.
-
-   - Look for the most recent build of the pull request in the `GitHub
-     workflows for the repo`_.
-
-   Success by CI is a strong indication that this procedure will be
-   quick and successful.
-
-   If CI builds failed, you can still execute `the merging procedure`_
-   if you believe that the failure is due to merge conflicts that you
-   are willing to resolve.
-
-   If CI builds are missing, inform sysadmins that CI isn't
-   functioning.
+   If the branch built OK but there is a failed build *of the trial
+   merge*, you can still execute `the merging procedure`_ if you
+   believe that the failure is due to merge conflicts that you are
+   willing to resolve.
 
    If you have no build and test results for the merge, then you can
-   still execute `the merging procedure`_ if:
+   still try to execute `the merging procedure`_ if:
 
    #. you believe there are only merge conflicts,
    #. you're willing to try to resolve those conflicts, and

--- a/procedure/pull-request-merge.rst
+++ b/procedure/pull-request-merge.rst
@@ -109,9 +109,6 @@ resolving are noted in square brackets.
    #. you're willing to try to resolve those conflicts, and
    #. you're prepared to test on all target platforms.
 
-[Checklist items for Customer-specific branches from branch-merge.rst
-omitted for now.  RB 2023-01-07]
-
 .. _Travis CI build history for the repo: https://app.travis-ci.com/github/Ravenbrook/mps/builds
 
 

--- a/procedure/pull-request-merge.rst
+++ b/procedure/pull-request-merge.rst
@@ -207,9 +207,14 @@ These steps will only rarely need repeating.
    branch.  If you still can't resolve conflicts, this procedure
    fails.
 
-5. [This step is only necessary if the merge was non-trivial, there
-   has been rebasing, or CI results are not available.  RB 2023-01-12]
-   Build and test the results locally.  For example::
+5. If either
+
+   - the merge was non-trivial
+   - there has been any rebasing (see step 7)
+   - you don't have pull request build results from CI
+
+   then build and test the merge result locally if possible.  For
+   example::
 
      make -C code -f lii6gc.gmk testci testansi testpollnone testmmqa
 
@@ -221,23 +226,22 @@ These steps will only rarely need repeating.
    fails, and you need to go back to the source of the branch,
    e.g. the pull request and its original author.  Something's wrong!
 
-6. [This step is only necessary if the merge was non-trivial, there
-   has been rebasing, or CI results are not available.  RB 2023-01-12]
-   Push the merge to a fresh branch in the Ravenbrook MPS GitHub
-   repository to trigger building and testing on all target platforms
-   using Travis CI. ::
+6. If either
+
+   - the merge was non-trivial
+   - there has been any rebasing (see step 7)
+   - you don't have pull request build results from CI
+
+   then push the merge to a fresh branch in the `Ravenbrook MPS repo
+   on GitHub`_ to trigger CI to build and testing on all target
+   platforms. ::
 
      git push github merge/2023-01-06/speed-hax
 
-   You will need to wait for results from Travis CI.  [Add details of
-   how to see them.  RB 2023-07-01]
+   You will need to wait for results from CI.  [Add details of how to
+   see them.  RB 2023-07-01]
 
    See build (step 5) about what to do if tests do not pass.
-
-   Note: This potentially creates a branch in the GitHub repo ahead
-   of Git Fusion doing so, but it will the same name, because of the
-   Git Fusion mapping, and so the result is the same as if it had come
-   in via Perforce.
 
 7. Submit your merged master and the branch to Perforce::
 

--- a/procedure/pull-request-merge.rst
+++ b/procedure/pull-request-merge.rst
@@ -65,7 +65,8 @@ checklist, decide whether to continue with the procedure.
    "Contributing to the MPS" <../contributing.rst#licensing>`_.)
 
    If they have expressed a variation, talk to them or get someone to
-   talk to them about the matter.  *Do not proceed with merging*.
+   talk to them about the matter.  *Do not start the merging
+   procedure*.
 
 #. Does the branch build and pass tests on all `target platforms
    <../readme.txt>`_?

--- a/procedure/pull-request-merge.rst
+++ b/procedure/pull-request-merge.rst
@@ -219,10 +219,10 @@ These steps will only rarely need repeating.
      git push ravenbrook master branch/2023-01-06/speed-hax
 
    If this fails because someone has submitted changes to the master
-   codeline since you started, pull those changes and go back to
-   merging (step 4). ::
+   codeline since you started.  Replace your master with those changes
+   and go back to merging (step 4). ::
 
-     git pull ravenbrook master
+     git pull --force ravenbrook master:master
 
 9. If and *only if* the Perforce push (step 8) succeeds, you can
    also push to GitHub::

--- a/procedure/pull-request-merge.rst
+++ b/procedure/pull-request-merge.rst
@@ -139,7 +139,7 @@ These steps will only rarely need repeating.
      cd mps
 
 #. Set your e-mail address for commits to the repo to match the one in
-   your Perforce user record. ::
+   your Perforce user record, e.g. ::
 
      git config user.email spqr@ravenbrook.com
 
@@ -155,15 +155,20 @@ These steps will only rarely need repeating.
 1. `Fetch the pull request branch`_ to a local branch using the MPS
    durable branch naming convention, "branch/DATE/TOPIC".
 
-   If branch is in the `Ravenbrook MPS repo on GitHub`_ and already
-   has a conventional name, then use the existing name, e.g. ::
+   If the branch already has a conventional name, and it's in the
+   `Ravenbrook MPS repo on GitHub`_ then fetch it with the existing
+   name, e.g. ::
 
      git fetch github branch/2023-01-06/speed-hax:branch/2023-01-06/speed-hax
 
-   Otherwise, if the pull request is from the `Ravenbrook MPS repo on
-   GitHub`_, fetch it from the pull request, e.g. ::
+   Otherwise, if the pull request is in the `Ravenbrook MPS repo on
+   GitHub`_, fetch it from the pull request and give it a conventional
+   name, e.g. ::
 
      git fetch github pull/93/head:branch/2023-01-06/speed-hax
+
+   (This could happen if either the pull request is from a fork or the
+   branch has an unconventional name.)
 
    If the branch to be merged is in a third-party repo, such as a fork
    not on GitHub, you can fetch it using a remote, e.g.::

--- a/procedure/pull-request-merge.rst
+++ b/procedure/pull-request-merge.rst
@@ -217,7 +217,7 @@ These steps will only rarely need repeating.
 
    - the merge was non-trivial
    - there has been any rebasing (see step 7)
-   - you don't have pull request build results from CI
+   - you haven't checked pull request build results from CI
 
    then build and test the merge result locally if possible.  For
    example::
@@ -236,7 +236,7 @@ These steps will only rarely need repeating.
 
    - the merge was non-trivial
    - there has been any rebasing (see step 7)
-   - you don't have pull request build results from CI
+   - you haven't checked pull request build results from CI
 
    then push the merge to a fresh branch in the `Ravenbrook MPS repo
    on GitHub`_ to trigger CI to build and testing on all target

--- a/procedure/pull-request-merge.rst
+++ b/procedure/pull-request-merge.rst
@@ -346,11 +346,11 @@ A squash merge compresses development history into a single commit,
 destroying the record of what happened during development and the
 connection to the branch.
 
-The main motivation for fast-forwards and squashes appears to be to
-simplify the branching history so that it's easier to understand.
-Better tools and interfaces are no doubt required for analysing Git
-history.  These will emerge.  And they will be able to analyse the
-history that we are creating today.
+Many developers use fast-forwards and squashes to simplify the
+branching history so that it's easier to understand.  Better tools and
+interfaces are no doubt required for analysing Git history.  These
+will emerge.  And they will be able to analyse the history that we are
+creating today.
 
 There is also a strong tendency among developers to "correct" mistakes
 and edit history to reflect "what should have happened" or "what I

--- a/procedure/pull-request-merge.rst
+++ b/procedure/pull-request-merge.rst
@@ -113,7 +113,7 @@ checklist, decide whether to start `the merging procedure`_.
    - Look for the most recent build of the pull request in the `GitHub
      workflows for the repo`_.
 
-   Success by CI is a strong indication that this procecure will be
+   Success by CI is a strong indication that this procedure will be
    quick and successful.
 
    If CI builds failed, you can still execute `the merging procedure`_

--- a/procedure/pull-request-merge.rst
+++ b/procedure/pull-request-merge.rst
@@ -8,7 +8,6 @@ Memory Pool System pull request merge procedure
 :confidentiality: public
 :copyright: See `C. Copyright and License`_
 :readership: MPS developers, trainee integrators
-:status: draft
 
 
 1. Introduction
@@ -26,9 +25,6 @@ steps from our Perforce-based "Memory Pool System branching and
 merging procedures" [GDR_2014-01-09]_ with Gareth Rees' email
 containing the working steps for git / GitHub merges, "Re: Possible
 MPS Help" [GDR_2020-09-03]_ .
-
-The document is still draft.  Some of the questions that need
-resolving are noted in square brackets.
 
 
 2. Pre-merge checklist

--- a/procedure/pull-request-merge.rst
+++ b/procedure/pull-request-merge.rst
@@ -136,6 +136,12 @@ These steps will only rarely need repeating.
    repo.)  ::
 
      git clone -o github git@github.com:Ravenbrook/mps.git
+     cd mps
+
+#. Set your e-mail address for commits to the repo to match the one in
+   your Perforce user record. ::
+
+     git config user.email spqr@ravenbrook.com
 
 #. Add the Git Fusion mps-public repo, which is the interface to
    Ravenbrook's Perforce. ::

--- a/procedure/pull-request-merge.rst
+++ b/procedure/pull-request-merge.rst
@@ -85,15 +85,15 @@ checklist, decide whether to continue with the procedure.
    - Look for the most recent build of the branch in the `GitHub
      workflows for the repo`_.
 
-   If there is a failed build you should not execute this procedure,
-   but talk to the contributor about fixing the branch.
+   If there is a failed build you should not execute `the merging
+   procedure`_, but talk to the contributor about fixing the branch.
 
    If the branch is in the `Ravenbrook MPS repo on GitHub`_ and builds
    are missing from the "checks" section of pull request, inform
    sysadmins that CI isn't functioning.
 
-   If you have no build and test results, you can still execute this
-   procedure, with caution.
+   If you have no build and test results, you can still execute `the
+   merging procedure`_, with caution.
 
 #. Does the branch merge cleanly in to master and pass tests on all
    target platforms?
@@ -116,15 +116,15 @@ checklist, decide whether to continue with the procedure.
    Success by CI is a strong indication that this procecure will be
    quick and successful.
 
-   If CI builds failed, you can still execute this procedure if you
-   believe that the failure is due to merge conflicts that you are
-   willing to resolve.
+   If CI builds failed, you can still execute `the merging procedure`_
+   if you believe that the failure is due to merge conflicts that you
+   are willing to resolve.
 
    If CI builds are missing, inform sysadmins that CI isn't
    functioning.
 
    If you have no build and test results for the merge, then you can
-   still execute this procedure if:
+   still execute `the merging procedure`_ if:
 
    #. you believe there are only merge conflicts,
    #. you're willing to try to resolve those conflicts, and
@@ -165,6 +165,8 @@ These steps will only rarely need repeating.
 
      git remote add perforce ssh://git@perforce.ravenbrook.com:1622/mps-public
 
+
+.. _the merging procedure:
 
 4. Merging procedure
 --------------------

--- a/procedure/pull-request-merge.rst
+++ b/procedure/pull-request-merge.rst
@@ -171,7 +171,7 @@ These steps will only rarely need repeating.
      git checkout branch/2023-01-06/speed-hax
      git merge master
 
-   Edit the commit message to say something like:
+   Edit the commit message to say something like::
 
      Merging branch/2023-01-06/speed-hax for pull request 93
      <https://github.com/Ravenbrook/mps/pull/93>.

--- a/procedure/pull-request-merge.rst
+++ b/procedure/pull-request-merge.rst
@@ -53,9 +53,10 @@ you should probably read section "`6. Rationale`_".
 
 The answers to these questions should be "yes".  If the answer to a
 question isn't "yes", record that, and why, in response to the pull
-request (and maybe suggest what to do about it).  When you finish the
-checklist, decide whether to start `the merging procedure`_ by
-considering `2. Purpose`_.
+request (and maybe suggest what to do about it).  Include a permalink
+to the revision of this procedure that you are following.  When you
+finish the checklist, decide whether to start `the merging procedure`_
+by considering `2. Purpose`_.
 
 #. Is there a permanent visible document (issue, job), referenced by
    the branch, recording the problem that is solved by the changes in

--- a/procedure/pull-request-merge.rst
+++ b/procedure/pull-request-merge.rst
@@ -143,30 +143,27 @@ These steps will only rarely need repeating.
 4. Merging a development branch
 -------------------------------
 
-1. If the branch to be merged is in a third-party repo (such as a
-   fork), then add that, e.g.::
+1. `Fetch the pull request branch`_ to a local branch using the MPS
+   durable branch naming convention, "branch/DATE/TOPIC", e.g. ::
+
+     git fetch github pull/93/head:branch/2022-12-23/hardened-runtime
+
+   If the branch to be merged is in a third-party repo, such as a fork
+   not on GitHub, you can fetch it usina a remote, e.g.::
 
      git remote add captain-contrib https://gitlab.com/captcontrib/mps.git
-
-2. Fetch the branch that you are going to merge to a local branch
-   using the MPS durable branch naming convention,
-   "branch/DATE/TOPIC", e.g. ::
-
      git fetch captain-contrib mps-speed-hax:branch/2023-01-06/speed-hax
 
-   Double check you've got this right.  Using the wrong branch naming
-   `causes permanent pollution in the Ravenbrook Perforce repository
+   Double check you've got the branch name right.  Using the wrong
+   branch naming `causes permanent pollution in the Ravenbrook
+   Perforce repository
    <https://info.ravenbrook.com/mail/2023/01/07/15-06-41/0/>`_.
 
-   [How does this affect the connection between the branch and the
-   pull request and issues?  We want to retain that connection
-   forever.  RB 2023-01-08]
+2. Optionally, let other people know that you're working on a merge
+   into master.  Negotiate to avoid racing them to the push (step 7)
+   because that will create extra merging work.
 
-3. Optionally, let other people know that you're about to merge into
-   master, and negotiate to avoid racing them to the push (step 8) and
-   making extra work for everyone.
-
-4. Merge master with the branch::
+3. Merge master with the branch::
 
      git pull perforce master:master
      git checkout branch/2023-01-06/speed-hax
@@ -177,7 +174,7 @@ These steps will only rarely need repeating.
    branch.  If you still can't resolve conflicts, this procedure
    fails.
 
-5. Build and test the results locally.  For example::
+4. Build and test the results locally.  For example::
 
      make -C code -f lii6gc.gmk testci testansi testpollnone testmmqa
 
@@ -185,11 +182,11 @@ These steps will only rarely need repeating.
    platforms.
 
    If tests do not pass, review your conflict resolution from the
-   merge (step 4), and if that doesn't resolve things, the procedure
+   merge (step 3), and if that doesn't resolve things, the procedure
    fails, and you need to go back to the source of the branch,
    e.g. the pull request and its original author.  Something's wrong!
 
-6. Push the branch to the Ravenbrook MPS GitHub repository to trigger
+5. Push the branch to the Ravenbrook MPS GitHub repository to trigger
    building and testing on all target platforms using Travis CI. ::
 
      git push github branch/2023-01-06/speed-hax
@@ -197,34 +194,34 @@ These steps will only rarely need repeating.
    You will need to wait for results from Travis CI.  [Add details of
    how to see them.  RB 2023-07-01]
 
-   See build (step 5) about what to do if tests do not pass.
+   See build (step 4) about what to do if tests do not pass.
 
    Note: This potentially creates a branch in the GitHub repo ahead
    of Git Fusion doing so, but it will the same name, because of the
    Git Fusion mapping, and so the result is the same as if it had come
    in via Perforce.
 
-7. Replace the master with your merged branch::
+6. Replace the master with your merged branch::
 
      git checkout master
      git merge --ff-only branch/2023-01-06/speed-hax
 
    The ``--ff-only`` flag ensures there have been no changes on master
-   since merging (step 4), so that the testing is valid for master,
+   since merging (step 3), so that the testing is valid for master,
    and we do not create a second merge commit.  If this fails, go back
-   to merging (step 4).
+   to merging (step 3).
 
-8. Push master and the branch to Perforce via Git Fusion::
+7. Push master and the branch to Perforce via Git Fusion::
 
      git push perforce master branch/2023-01-06/speed-hax
 
    If this fails because someone has submitted changes to the master
    codeline since you started.  Replace your master with those changes
-   and go back to merging (step 4). ::
+   and go back to merging (step 3). ::
 
      git pull --force perforce master:master
 
-9. If and *only if* the Perforce push (step 8) succeeds, you can
+8. If and *only if* the Perforce push (step 7) succeeds, you can
    also push to GitHub::
 
      git push github master branch/2023-01-06/speed-hax
@@ -241,6 +238,8 @@ These steps will only rarely need repeating.
    2. Check (or ask a sysadmin to check) that gitpushbot is running
       on Berunda and restart it if necessary, or ask a sysadmin to do
       this.
+
+.. _Fetch the pull request branch: https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/reviewing-changes-in-pull-requests/checking-out-pull-requests-locally#modifying-an-inactive-pull-request-locally
 
 
 5. Rationale
@@ -276,9 +275,9 @@ that there has been a merge, by whom, from where, etc.  It discards
 that information.  Therefore we want to discourage fast-forwards of
 master in favour of merges.
 
-Given this, the replace (step 7) may seem odd, since it fast-forwards
+Given this, the replace (step 6) may seem odd, since it fast-forwards
 master.  But in fact it's pointing master at the merge commit created
-earlier (step 5), so that master has a history including a proper
+earlier (step 4), so that master has a history including a proper
 merge.
 
 

--- a/procedure/pull-request-merge.rst
+++ b/procedure/pull-request-merge.rst
@@ -253,6 +253,10 @@ GitHub provides a merge button on pull requests.  According to
 [Chaser324_2017]_ it only works for branches that can fast-forward
 master, and also only creates fast-forwards.
 
+[This might not be true.  See `About merge methods on GitHub
+<https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/configuring-pull-request-merges/about-merge-methods-on-github>`_.
+RB 2023-01-09]
+
 There are two reasons this is undesirable.
 
 Firstly, it's quite likely that a pull request has a branch that isn't

--- a/procedure/pull-request-merge.rst
+++ b/procedure/pull-request-merge.rst
@@ -93,8 +93,6 @@ considering `2. Purpose`_.
    talk to them about the matter.  *Do not start the merging
    procedure*.
 
-.. _checked pull request build results from CI:
-
 #. Does the branch, and its merge, build and pass tests?
 
    CI should have run builds of both the branch, and a *trial merge*
@@ -247,7 +245,7 @@ These steps will only rarely need repeating.
 
    - the merge was non-trivial
    - there has been any rebasing (see step 7)
-   - you haven't `checked pull request build results from CI`_
+   - there were failed or missing build results from CI
 
    then build and test the merge result locally if possible.  For
    example::
@@ -266,7 +264,7 @@ These steps will only rarely need repeating.
 
    - the merge was non-trivial
    - there has been any rebasing (see step 7)
-   - you haven't `checked pull request build results from CI`_
+   - there were failed or missing build results from CI
 
    then push the merge to a fresh branch in the `Ravenbrook MPS repo
    on GitHub`_ to trigger CI to build and testing on all target

--- a/procedure/pull-request-merge.rst
+++ b/procedure/pull-request-merge.rst
@@ -182,7 +182,11 @@ These steps will only rarely need repeating.
 
    Otherwise, if the pull request is in the `Ravenbrook MPS repo on
    GitHub`_, fetch it from the pull request and give it a conventional
-   name, e.g. ::
+   name, like this ::
+
+     git fetch github pull/$PR/head:$BRANCH
+
+   For example ::
 
      git fetch github pull/93/head:branch/2023-01-06/speed-hax
 

--- a/procedure/pull-request-merge.rst
+++ b/procedure/pull-request-merge.rst
@@ -71,15 +71,26 @@ checklist, decide whether to continue with the procedure.
 #. Does the branch build and pass tests on all `target platforms
    <../readme.txt>`_?
 
-   If the branch is in the `Ravenbrook MPS repo on GitHub`_ then
-   Travis CI should have run builds.  Look for a successful build in
-   the `Travis CI build history for the repo`_.  If there is a failed
-   build you should not execute this procedure, but talk to the
-   contributor about fixing the branch.
+   If the branch is in the `Ravenbrook MPS repo on GitHub`_ then CI
+   should have run builds of the branch.  To check, either:
 
-   If the branch is in the `Ravenbrook MPS repo on GitHub`_ and Travis
-   builds are missing, inform sysadmins that Travis CI isn't
-   functioning.
+   - Look for build results for the branch (not the pull request) in
+     the "checks" section of the pull request on GitHub.  Expand "Show
+     all checks", and look for build success messages *for the
+     branch*.
+
+   - Look for a the most recent build of the branch in the `Travis CI
+     build history for the repo`_.
+
+   - Look for the most recent build of the branch in the `GitHub
+     workflows for the repo`_.
+
+   If there is a failed build you should not execute this procedure,
+   but talk to the contributor about fixing the branch.
+
+   If the branch is in the `Ravenbrook MPS repo on GitHub`_ and builds
+   are missing from the "checks" section of pull request, inform
+   sysadmins that CI isn't functioning.
 
    If you have no build and test results, you can still execute this
    procedure, with caution.
@@ -87,26 +98,29 @@ checklist, decide whether to continue with the procedure.
 #. Does the branch merge cleanly in to master and pass tests on all
    target platforms?
 
-   Travis CI should have run builds of the pull request (i.e. `of a
-   merge with master
+   CI should have run builds of the pull request (i.e. `of a merge
+   with master
    <https://docs.travis-ci.com/user/pull-requests/#how-pull-requests-are-built>`_).
    To check, either:
 
-   - Look for "All checks have passed" in the pull request on GitHub.
-     Expand "Show all checks", and look for build success messages
-     from Travis CI.
+   - Look for build results for the pull request (not the branch) in
+     the pull request on GitHub.  Expand "Show all checks", and look
+     for build success messages *for the pull request*.
 
-   - Look for a successful build in the `Travis CI build history for
-     the repo`_.
+   - Look for a successful build of the pull request in the `Travis CI
+     build history for the repo`_.
 
-   Success by Travis CI is a strong indication that this procecure
-   will be quick and successful.
+   - Look for the most recent build of the pull request in the `GitHub
+     workflows for the repo`_.
 
-   If Travis builds failed, you can still execute this procedure if
-   you believe that the failure is due to merge conflicts that you are
+   Success by CI is a strong indication that this procecure will be
+   quick and successful.
+
+   If CI builds failed, you can still execute this procedure if you
+   believe that the failure is due to merge conflicts that you are
    willing to resolve.
 
-   If Travis builds are missing, inform sysadmins that Travis CI isn't
+   If CI builds are missing, inform sysadmins that CI isn't
    functioning.
 
    If you have no build and test results for the merge, then you can
@@ -117,6 +131,8 @@ checklist, decide whether to continue with the procedure.
    #. you're prepared to test on all target platforms.
 
 .. _Travis CI build history for the repo: https://app.travis-ci.com/github/Ravenbrook/mps/builds
+
+.. _GitHub workflows for the repo: https://github.com/Ravenbrook/mps/actions
 
 
 3. Prerequisite steps

--- a/procedure/pull-request-merge.rst
+++ b/procedure/pull-request-merge.rst
@@ -148,6 +148,16 @@ by considering `2. Purpose`_.
 
 These steps will only rarely need repeating.
 
+#. You need basic competence with Git: enough to understand the
+   commands in `the merging procedure`_.
+
+#. If the merge has conflicts, you will need competence in using Git
+   to resolve merge conflicts.
+
+#. If you want to vary the procedure, you will need to understand how
+   Perforce Git Fusion [Perforce_2017]_ connects Ravenbrook's Perforce
+   repository to the `Ravenbrook MPS repo on GitHub`_.
+
 #. Ensure your public SSH key is submitted in Perforce at
    //.git-fusion/users/USER/keys/
 
@@ -178,6 +188,10 @@ These steps will only rarely need repeating.
 
 5. Merging procedure
 --------------------
+
+Note: At any point before a successful "push" in step 7, this
+procedure can be abandoned without harm.  All work is local to your
+working repo before that point.
 
 1. `Fetch the pull request branch`_ to a local branch using the MPS
    `durable branch naming convention`_, "branch/DATE/TOPIC".
@@ -478,6 +492,10 @@ A. References
 		    <https://info.ravenbrook.com/project/mps/master/procedure/branch-merge>,
 		    <https://github.com/Ravenbrook/mps/blob/e78c6e16735d7f16ef86a7f2f8356791a18c8a6e/procedure/branch-merge.rst>.
 
+.. [Perforce_2017] "HelixCode Git Fusion Guide (2017.2)"; Perforce
+                   Software; 2017;
+                   <https://www.perforce.com/manuals/git-fusion/>.
+
 
 B. Document History
 -------------------
@@ -487,6 +505,7 @@ B. Document History
 2023-01-13  RB_    Updates after `first attempt at execution`_.
 2023-01-14  RB_    Updates after `second (successful) execution`_.
 2023-01-23  RB_    Adding measurements.
+2023-01-25  RB_    Responding to mini-review_.
 ==========  =====  ==================================================
 
 .. _RB: mailto:rb@ravenbrook.com
@@ -494,6 +513,8 @@ B. Document History
 .. _first attempt at execution: https://github.com/Ravenbrook/mps/pull/97#issuecomment-1380206348
 
 .. _second (successful) execution: https://github.com/Ravenbrook/mps/pull/97#issuecomment-1381771818
+
+.. _mini-review: https://github.com/Ravenbrook/mps/pull/97#discussion_r1085584810
 
 
 C. Copyright and License

--- a/procedure/pull-request-merge.rst
+++ b/procedure/pull-request-merge.rst
@@ -20,6 +20,11 @@ Ravenbrook is currently (2023-01) `migrating the MPS project to git
 (and GitHub) <https://github.com/Ravenbrook/mps/issues/98>`_ and that
 will greatly simplify this procedure.
 
+This procedure assumes a pull request has been received via GitHub,
+but that dependency is light.  The procedure can be varied for other
+sources, even where the "pull request" is received by email or some
+other traceable document.
+
 This document was created as a combination of the process improvement
 steps from our Perforce-based "Memory Pool System branching and
 merging procedures" [GDR_2014-01-09]_ with Gareth Rees' email

--- a/procedure/pull-request-merge.rst
+++ b/procedure/pull-request-merge.rst
@@ -303,7 +303,8 @@ So, `once Git becomes the home
 <https://github.com/Ravenbrook/mps/issues/98>`_ we will be able to use
 the button to to replace sections 3 and 4, the procedure, but not
 section 2, the pre-merge checklist.  We may be able to incorporate the
-checklist into GitHub's interface.
+checklist into GitHub's interface using a `pull request template
+<https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/creating-a-pull-request-template-for-your-repository>`_.
 
 
 5.3. Why the "durable" branch names?

--- a/procedure/pull-request-merge.rst
+++ b/procedure/pull-request-merge.rst
@@ -148,8 +148,8 @@ by considering `2. Purpose`_.
 
 These steps will only rarely need repeating.
 
-#. You need basic competence with Git: enough to understand the
-   commands in `the merging procedure`_.
+#. You need basic competence with Git: enough to understand what the
+   commands in `the merging procedure`_ do.
 
 #. If the merge has conflicts, you will need competence in using Git
    to resolve merge conflicts.

--- a/procedure/pull-request-merge.rst
+++ b/procedure/pull-request-merge.rst
@@ -365,7 +365,7 @@ RB 2023-01-14]
 
 
 6.1. Why not rebase or squash merge?
-------------------------------------
+....................................
 
 We would like to avoid rewriting history and the destruction of
 information on the grounds that it destroys information that could be
@@ -403,7 +403,7 @@ and so we should not edit it.
 
 
 6.2. Why not press the GitHub merge button?
--------------------------------------------
+...........................................
 
 We cannot use the GitHub pull request merge button because it would
 put the GitHub master branch out of sync with (ahead of) Perforce.
@@ -442,7 +442,7 @@ checklist into GitHub's interface using a `pull request template
 .. _durable branch naming convention:
 
 6.3. Why the "durable" branch names?
-------------------------------------
+....................................
 
 It's common in Git culture to delete branches once they've been
 merged [Ardalis_2017]_ but this destroys information that has been

--- a/procedure/pull-request-merge.rst
+++ b/procedure/pull-request-merge.rst
@@ -148,12 +148,12 @@ These steps will only rarely need repeating.
 
      git fetch github pull/93/head:branch/2023-01-06/speed-hax
 
-   If the pull request is from the Ravenbrook MPS repo on GitHub then
-   its branch may already have a conventional name.  Use the existing
+   If the pull request is from the Ravenbrook MPS repo on GitHub, and
+   its branch already has a conventional name, then use the existing
    name.
 
    If the branch to be merged is in a third-party repo, such as a fork
-   not on GitHub, you can fetch it usina a remote, e.g.::
+   not on GitHub, you can fetch it using a remote, e.g.::
 
      git remote add captain-contrib https://gitlab.com/captcontrib/mps.git
      git fetch captain-contrib mps-speed-hax:branch/2023-01-06/speed-hax

--- a/procedure/pull-request-merge.rst
+++ b/procedure/pull-request-merge.rst
@@ -79,7 +79,7 @@ by considering `2. Purpose`_.
    (without the branch) and that that the problem is solved (with the
    branch)?
 
-#. If there are interface changes, are they documented?
+#. If there changes to the `MPS interface`_, are they documented?
 
 #. If the changes are significant and user-visible, is there an update
    to the release notes (``manual/source/release.rst``)?
@@ -139,6 +139,8 @@ by considering `2. Purpose`_.
 .. _Travis CI build history for the repo: https://app.travis-ci.com/github/Ravenbrook/mps/builds
 
 .. _GitHub workflows for the repo: https://github.com/Ravenbrook/mps/actions
+
+.. _MPS interface: https://www.ravenbrook.com/project/mps/master/manual/html/topic/interface.html
 
 
 4. Prerequisite steps
@@ -329,12 +331,12 @@ These steps will only rarely need repeating.
       on Berunda and restart it if necessary, or ask a sysadmin to do
       this.
 
-.. _Fetch the pull request branch: https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/reviewing-changes-in-pull-requests/checking-out-pull-requests-locally#modifying-an-inactive-pull-request-locally
-
 9. Eyeball the pull request and related issues on GitHub to make sure
    the merge was recorded correctly.  Check that any issues *not
    completely resolved* by the merge were not closed.  Re-open them if
    necessary.
+
+.. _Fetch the pull request branch: https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/reviewing-changes-in-pull-requests/checking-out-pull-requests-locally#modifying-an-inactive-pull-request-locally
 
 
 6. Rationale

--- a/procedure/pull-request-merge.rst
+++ b/procedure/pull-request-merge.rst
@@ -462,10 +462,15 @@ B. Document History
 
 ==========  =====  ==================================================
 2023-01-07  RB_    Created.
-2023-01-13  RB_    Updates after first attempt at execution.
+2023-01-13  RB_    Updates after `first attempt at execution`_.
+2023-01-14  RB_    Updates after `second (successful) execution`_.
 ==========  =====  ==================================================
 
 .. _RB: mailto:rb@ravenbrook.com
+
+.. _first attempt at execution: https://github.com/Ravenbrook/mps/pull/97#issuecomment-1380206348
+
+.. _second (successful) execution: https://github.com/Ravenbrook/mps/pull/97#issuecomment-1381771818
 
 
 C. Copyright and License

--- a/procedure/pull-request-merge.rst
+++ b/procedure/pull-request-merge.rst
@@ -57,6 +57,14 @@ checklist, decide whether to start `the merging procedure`_.
 
 #. Has there been a code review?
 
+#. Is the merge approved by an approving review?
+
+   The `Ravenbrook MPS repo on GitHub`_ is set to require an approving
+   review and GitHub will block a push (step 8) without one.  If you
+   push an unapproved merge to Perforce, this will cause gitpushbot to
+   fail, and leave Perforce and GitHub out of sync.  *Do not push to
+   Perforce without GitHub approval.*
+
 #. Has the contributor licensed their work?
 
    By default, the work is licensed if the contributor has not

--- a/procedure/pull-request-merge.rst
+++ b/procedure/pull-request-merge.rst
@@ -267,13 +267,14 @@ These steps will only rarely need repeating.
    - there were failed or missing build results from CI
 
    then push the merge to a fresh branch in the `Ravenbrook MPS repo
-   on GitHub`_ to trigger CI to build and testing on all target
-   platforms. ::
+   on GitHub`_.  This should trigger CI to build and testing on all
+   target platforms. ::
 
      git push github merge/2023-01-06/speed-hax
 
-   You will need to wait for results from CI.  [Add details of how to
-   see them.  RB 2023-07-01]
+   You will need to wait for results from CI.  Look for a build
+   results in the `Travis CI build history for the repo`_ and in the
+   `GitHub workflows for the repo`_.
 
    See build (step 5) about what to do if tests do not pass.
 

--- a/procedure/pull-request-merge.rst
+++ b/procedure/pull-request-merge.rst
@@ -17,6 +17,10 @@ Memory Pool System pull request merge procedure
 This document contains a procedure for merging a branch received via a
 GitHub "pull request".
 
+Ravenbrook is currently (2023-01) `migrating the MPS project to git
+(and GitHub) <https://github.com/Ravenbrook/mps/issues/98>`_ and that
+will greatly simplify this procedure.
+
 This document was created as a combination of the process improvement
 steps from our Perforce-based "Memory Pool System branching and
 merging procedures" [GDR_2014-01-09]_ with Gareth Rees' email
@@ -25,10 +29,6 @@ MPS Help" [GDR_2020-09-03]_ .
 
 The document is still draft.  Some of the questions that need
 resolving are noted in square brackets.
-
-Ravenbrook is currently (2023-01) `migrating the MPS project to git
-(and GitHub) <https://github.com/Ravenbrook/mps/issues/98>`_ and this
-is likely to modify and simplify this procedure.
 
 
 2. Pre-merge checklist
@@ -120,7 +120,7 @@ omitted for now.  RB 2023-01-07]
 
 These steps will only rarely need repeating.
 
-#. Ensure your public key is submitted in Perforce at
+#. Ensure your public SSH key is submitted in Perforce at
    //.git-fusion/users/USER/keys/
 
 #. Ensure your e-mail address is submitted in Perforce at

--- a/procedure/pull-request-merge.rst
+++ b/procedure/pull-request-merge.rst
@@ -208,10 +208,11 @@ These steps will only rarely need repeating.
 
 6. [This step is only necessary if the merge was non-trivial, there
    has been rebasing, or CI results are not available.  RB 2023-01-12]
-   Push the branch to the Ravenbrook MPS GitHub repository to trigger
-   building and testing on all target platforms using Travis CI. ::
+   Push the merge to a fresh branch in the Ravenbrook MPS GitHub
+   repository to trigger building and testing on all target platforms
+   using Travis CI. ::
 
-     git push github branch/2023-01-06/speed-hax
+     git push github merge/2023-01-06/speed-hax
 
    You will need to wait for results from Travis CI.  [Add details of
    how to see them.  RB 2023-07-01]

--- a/procedure/pull-request-merge.rst
+++ b/procedure/pull-request-merge.rst
@@ -171,6 +171,16 @@ These steps will only rarely need repeating.
      git checkout branch/2023-01-06/speed-hax
      git merge master
 
+   Edit the commit message to say something like:
+
+     Merging branch/2023-01-06/speed-hax for pull request 93
+     <https://github.com/Ravenbrook/mps/pull/93>.
+
+   Do *not* just say "pull request 93" without a link, because that
+   number is local to, and only valid on GitHub.  Bear this in mind
+   for other references.  Do add any other links that would increase
+   traceability.
+
    You may need to resolve conflicts.  If you can't resolve conflicts
    yourself, you may need to involve the original author of the
    branch.  If you still can't resolve conflicts, this procedure

--- a/procedure/pull-request-merge.rst
+++ b/procedure/pull-request-merge.rst
@@ -64,13 +64,13 @@ resolving are noted in square brackets.
 #. Does the branch build and pass tests on all `target platforms
    <../readme.txt>`_?
 
-   If the branch is in the Ravenbrook MPS repo on GitHub then Travis
-   CI should have run builds.  Look for a successful build in the
-   `Travis CI build history for the repo`_.  If there is a failed
+   If the branch is in the `Ravenbrook MPS repo on GitHub`_ then
+   Travis CI should have run builds.  Look for a successful build in
+   the `Travis CI build history for the repo`_.  If there is a failed
    build you should not execute this procedure, but talk to the
    contributor about fixing the branch.
 
-   If the branch is in the Ravenbrook MPS repo on GitHub and Travis
+   If the branch is in the `Ravenbrook MPS repo on GitHub`_ and Travis
    builds are missing, inform sysadmins that Travis CI isn't
    functioning.
 
@@ -145,9 +145,9 @@ These steps will only rarely need repeating.
 
      git fetch github pull/93/head:branch/2023-01-06/speed-hax
 
-   If the pull request is from the Ravenbrook MPS repo on GitHub, and
-   its branch already has a conventional name, then use the existing
-   name.
+   If the pull request is from the `Ravenbrook MPS repo on GitHub`_,
+   and its branch already has a conventional name, then use the
+   existing name.
 
    If the branch to be merged is in a third-party repo, such as a fork
    not on GitHub, you can fetch it using a remote, e.g.::

--- a/procedure/pull-request-merge.rst
+++ b/procedure/pull-request-merge.rst
@@ -160,8 +160,8 @@ These steps will only rarely need repeating.
    <https://info.ravenbrook.com/mail/2023/01/07/15-06-41/0/>`_.
 
 2. Optionally, let other people know that you're working on a merge
-   into master.  Negotiate to avoid racing them to the push (step 7)
-   because that will create extra merging work.
+   into master.  Negotiate to avoid racing them to push to the master
+   codeline (step 7) because that will create extra merging work.
 
 3. Merge master with the branch::
 
@@ -182,7 +182,7 @@ These steps will only rarely need repeating.
    platforms.
 
    If tests do not pass, review your conflict resolution from the
-   merge (step 3), and if that doesn't resolve things, the procedure
+   merge (step 3), and if that doesn't fix things, the procedure
    fails, and you need to go back to the source of the branch,
    e.g. the pull request and its original author.  Something's wrong!
 
@@ -201,30 +201,23 @@ These steps will only rarely need repeating.
    Git Fusion mapping, and so the result is the same as if it had come
    in via Perforce.
 
-6. Replace the master with your merged branch::
+6. Submit your merged branch to Perforce::
 
-     git checkout master
-     git merge --ff-only branch/2023-01-06/speed-hax
+     git push Perforce branch/2023-01-06/speed-hax
 
-   The ``--ff-only`` flag ensures there have been no changes on master
-   since merging (step 3), so that the testing is valid for master,
-   and we do not create a second merge commit.  If this fails, go back
-   to merging (step 3).
+7. Submit your merged branch to the Perforce master codeline::
 
-7. Push master and the branch to Perforce via Git Fusion::
+     git push perforce branch/2023-01-06/speed-hax:master
 
-     git push perforce master branch/2023-01-06/speed-hax
+   **Important**: Do *not* force this push.
 
-   If this fails because someone has submitted changes to the master
-   codeline since you started.  Replace your master with those changes
-   and go back to merging (step 3). ::
+   If this fails, someone has submitted changes to the master codeline
+   since you started.  Go back to merging (step 3).
 
-     git pull --force perforce master:master
+8. Optionally, if and *only if* the Perforce push (step 7) succeeded,
+   you can also push to GitHub::
 
-8. If and *only if* the Perforce push (step 7) succeeds, you can
-   also push to GitHub::
-
-     git push github master branch/2023-01-06/speed-hax
+     git push github branch/2023-01-06/speed-hax:master
 
    If you don't do this, then within `30 minutes
    <https://info.ravenbrook.com/infosys/robots/gitpushbot/etc/crontab>`_
@@ -274,11 +267,6 @@ master.  A fast-forward means there is no commit that records the fact
 that there has been a merge, by whom, from where, etc.  It discards
 that information.  Therefore we want to discourage fast-forwards of
 master in favour of merges.
-
-Given this, the replace (step 6) may seem odd, since it fast-forwards
-master.  But in fact it's pointing master at the merge commit created
-earlier (step 4), so that master has a history including a proper
-merge.
 
 
 5.2. Why the "durable" branch names?

--- a/procedure/pull-request-merge.rst
+++ b/procedure/pull-request-merge.rst
@@ -153,15 +153,17 @@ These steps will only rarely need repeating.
 --------------------
 
 1. `Fetch the pull request branch`_ to a local branch using the MPS
-   durable branch naming convention, "branch/DATE/TOPIC", e.g. ::
+   durable branch naming convention, "branch/DATE/TOPIC".
 
-     git fetch github pull/93/head:branch/2023-01-06/speed-hax
-
-   If the pull request is from the `Ravenbrook MPS repo on GitHub`_,
-   and its branch already has a conventional name, then use the
-   existing name, e.g. ::
+   If branch is in the `Ravenbrook MPS repo on GitHub`_ and already
+   has a conventional name, then use the existing name, e.g. ::
 
      git fetch github branch/2023-01-06/speed-hax:branch/2023-01-06/speed-hax
+
+   Otherwise, if the pull request is from the `Ravenbrook MPS repo on
+   GitHub`_, fetch it from the pull request, e.g. ::
+
+     git fetch github pull/93/head:branch/2023-01-06/speed-hax
 
    If the branch to be merged is in a third-party repo, such as a fork
    not on GitHub, you can fetch it using a remote, e.g.::


### PR DESCRIPTION
This is a branch to deal with #96  by creating a [procedure for merging pull requests](https://github.com/Ravenbrook/mps/blob/branch/2023-01-07/pull-request-merge-procedure/procedure/pull-request-merge.rst), but also to work on [general git migration](https://github.com/Ravenbrook/mps/issues/98) relating to merges.

You might wonder at the amount of effort that has gone in to this piece of bureaucracy.  This is based on long experience with the MPS in defect prevention.  This procedure (and others like it) are the final gatekeeper on the quality of the source code, and have been key to prevention in the past.  GC bugs are very very nasty, especially when they happen to end-users of your user, who is likely a compiler developer, in a way that can't be seen or reproduced, let alone diagnosed and fixed.