### PR TITLE
Check shell scripts during CI

### DIFF
--- a/.github/workflows/shell-script-check.yml
+++ b/.github/workflows/shell-script-check.yml
@@ -12,7 +12,7 @@ on:
   - pull_request
 
 jobs:
-  checkrst:
+  checkshellscripts:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/shell-script-check.yml
+++ b/.github/workflows/shell-script-check.yml
@@ -1,0 +1,22 @@
+# .github/workflows/shell-script-check.yml -- check shell scripts
+#
+# This is a GitHub CI workflow
+# <https://docs.github.com/en/actions/using-workflows/about-workflows>
+# to check shell scripts.
+
+name: shell script check
+
+on:
+  # Run as part of CI checks on branch push and on merged pull request.
+  - push
+  - pull_request
+
+jobs:
+  checkrst:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Install shellcheck
+        run: sudo apt-get install -y shellcheck
+      - name: Check shell scripts
+        run: tool/checkshellscripts

--- a/.github/workflows/shell-script-check.yml
+++ b/.github/workflows/shell-script-check.yml
@@ -12,11 +12,11 @@ on:
   - pull_request
 
 jobs:
-  checkshellscripts:
+  check-shell-scripts:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
       - name: Install shellcheck
         run: sudo apt-get install -y shellcheck
       - name: Check shell scripts
-        run: tool/checkshellscripts
+        run: tool/check-shell-scripts

--- a/.github/workflows/shell-script-check.yml
+++ b/.github/workflows/shell-script-check.yml
@@ -10,6 +10,7 @@ on:
   # Run as part of CI checks on branch push and on merged pull request.
   - push
   - pull_request
+  - workflow_dispatch # allow manual triggering
 
 jobs:
   check-shell-scripts:

--- a/tool/check-shell-scripts
+++ b/tool/check-shell-scripts
@@ -1,5 +1,5 @@
 #!/bin/sh
-# tool/checkshellscripts -- check shell scripts in the MPS
+# tool/check-shell-scripts -- check shell scripts in the MPS
 #
 # Copyright (c) 2023 Ravenbrook Limited. See end of file for license.
 #

--- a/tool/check-shell-scripts
+++ b/tool/check-shell-scripts
@@ -9,11 +9,19 @@
 # It can be invoked from the command line of from Continuous
 # Integration scripts.
 #
-# The script excludes .git because it contains default Git Hooks
-# installed by git that trigger shellcheck.
+# Usage (in the root directory of the MPS tree)::
 #
-# The script ignores tool/autoconf because those scripts are part of
-# GNU autoconf and not under our control.
+#    tool/check-shell-scripts
+#
+# This script excludes some directories from checking:
+#
+# - It excludes .git because Git installs shell scripts (the default
+#   "Git Hooks") that provoke warnings from shellcheck, and we can't
+#   fix them.
+#
+# - It excludes tool/autoconf because those scripts are part of GNU
+#   autoconf, provoke warnings from shellcheck, and we can't fix them.
+#
 
 find . -path './.git' -prune -o \
      -path './tool/autoconf' -prune -o \
@@ -33,7 +41,9 @@ find . -path './.git' -prune -o \
 
 # A. REFERENCES
 #
-# [None]
+# [Shellcheck] "shellcheck - Shell script analysis tool" version
+#   0.8.0; Vidar Holen and contributors;
+#   <https://github.com/koalaman/shellcheck/blob/e5ad4cf420a7f7b8e5eaac872b14a1619051cf10/shellcheck.1.md>.
 #
 #
 # B. DOCUMENT HISTORY

--- a/tool/checkshellscripts
+++ b/tool/checkshellscripts
@@ -1,0 +1,73 @@
+#!/bin/sh
+# tool/checkshellscripts -- check shell scripts in the MPS
+#
+# Copyright (c) 2023 Ravenbrook Limited. See end of file for license.
+#
+# This script finds shell scripts in the MPS tree and runs shellcheck
+# on them to check for issues.
+#
+# It can be invoked from the command line of from Continuous
+# Integration scripts.
+#
+# The script excludes .git because it contains default Git Hooks
+# installed by git that trigger shellcheck.
+#
+# The script ignores tool/autoconf because those scripts are part of
+# GNU autoconf and not under our control.
+
+find . -path './.git' -prune -o \
+     -path './tool/autoconf' -prune -o \
+     -type f ! -name '*~' -print |
+{
+    code=0
+    while read -r f; do
+	if head -1 -- "$f" | grep -E -q -e '^#!/bin/(ba)?sh'; then
+	    # --format=gcc allows use of this script with Emacs M-x compile
+	    if ! shellcheck --format=gcc "$f"; then
+		code=1
+	    fi
+	fi
+    done
+    exit "$code"
+}
+
+# A. REFERENCES
+#
+# [None]
+#
+#
+# B. DOCUMENT HISTORY
+#
+# 2023-01-14 RB Created.
+#
+#
+# C. COPYRIGHT AND LICENSE
+#
+# Copyright (C) 2023 Ravenbrook Limited <https://www.ravenbrook.com/>.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are
+# met:
+#
+# 1. Redistributions of source code must retain the above copyright
+#    notice, this list of conditions and the following disclaimer.
+#
+# 2. Redistributions in binary form must reproduce the above copyright
+#    notice, this list of conditions and the following disclaimer in the
+#    documentation and/or other materials provided with the
+#    distribution.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+# IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED
+# TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+# PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+# HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+# SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+# LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+# DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+# THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#
+#
+# $Id$

--- a/tool/github-ci-kick
+++ b/tool/github-ci-kick
@@ -54,7 +54,7 @@ usage() {
     exit 1
 }    
 
-while getopts c:b:r:t: flag; do
+while getopts o:r:b:t: flag; do
     case "${flag}" in
 	b) branch="${OPTARG}";;
 	o) org="${OPTARG}";;

--- a/tool/testcoverage
+++ b/tool/testcoverage
@@ -26,14 +26,14 @@ case "$ARCH-$OS" in
     *-Darwin)
         CONFIGURATION=Debug
         (
-            cd -- "$CODE"
-            xcrun xcodebuild -config "$CONFIGURATION" clean
+            cd -- "$CODE" &&
+            xcrun xcodebuild -config "$CONFIGURATION" clean &&
             xcrun xcodebuild -config "$CONFIGURATION" -target testrun \
                 GCC_GENERATE_TEST_COVERAGE_FILES=YES \
                 GCC_INSTRUMENT_PROGRAM_FLOW_ARCS=YES
         )
         (
-            cd -- "$CODE/xc/$PROJECT.build/$CONFIGURATION/$PROJECT.build/Objects-normal/$ARCH"
+            cd -- "$CODE/xc/$PROJECT.build/$CONFIGURATION/$PROJECT.build/Objects-normal/$ARCH" &&
             xcrun gcov mps.c 2> /dev/null
         ) | "$TOOL/gcovfmt"
         ;;

--- a/tool/testemscripten
+++ b/tool/testemscripten
@@ -43,8 +43,9 @@ CLANG_REMOTE=https://github.com/kripken/emscripten-fastcomp-clang
 
 # Directory to put everything in
 TESTDIR="$PWD/.test"
-mkdir -p -- "$TESTDIR"
-cd -- "$TESTDIR"
+mkdir -p -- "$TESTDIR" &&
+    cd -- "$TESTDIR" ||
+	exit 1
 
 
 # 3. UTILITIES
@@ -61,7 +62,7 @@ checkout () {
         git clone --recursive -- "$REMOTE" "$REPO"
     fi
     (
-        cd -- "$REPO"
+        cd -- "$REPO" &&
         git pull
     )
 }
@@ -76,15 +77,15 @@ checkout emscripten "$EMSCRIPTEN_REMOTE"
 
 checkout emscripten-fastcomp "$FASTCOMP_REMOTE"
 (
-    cd emscripten-fastcomp
+    cd emscripten-fastcomp &&
     (
-        cd tools
+        cd tools &&
         checkout clang "$CLANG_REMOTE";
     )
     mkdir -p build
     (
-        cd build
-        ../configure --enable-optimized --disable-assertions --enable-targets=host,js
+        cd build &&
+        ../configure --enable-optimized --disable-assertions --enable-targets=host,js &&
         make;
     )
 )

--- a/tool/testopendylan
+++ b/tool/testopendylan
@@ -43,8 +43,9 @@ REMOTE=https://github.com/dylan-lang/opendylan.git
 
 # Directory to put everything in
 TESTDIR="$PWD/.test/$GC"
-mkdir -p -- "$TESTDIR"
-cd -- "$TESTDIR"
+mkdir -p -- "$TESTDIR" &&
+    cd -- "$TESTDIR" ||
+	exit 1
 
 
 # 3. PROCEDURE
@@ -116,7 +117,7 @@ if [ -f "$REPO/Makefile" ]; then
 else (
     cd -- "$REPO" &&
     ./autogen.sh &&
-    ./configure --with-gc="$GC" --prefix="$PREFIX" $CONFIGURE
+    ./configure --with-gc="$GC" --prefix="$PREFIX" "$CONFIGURE"
 ) fi
 (
     cd -- "$REPO" &&

--- a/tool/travis-ci-kick
+++ b/tool/travis-ci-kick
@@ -34,7 +34,7 @@ usage() {
     exit 1
 }    
 
-while getopts c:b:r:t: flag; do
+while getopts o:r:b:c:t: flag; do
     case "${flag}" in
 	c) commit="${OPTARG}";;
 	b) branch="${OPTARG}";;


### PR DESCRIPTION
To help prevent introduction of shell script errors.

Run the [shellcheck](https://www.shellcheck.net/) [linter](https://en.wikipedia.org/wiki/Lint_(software)) on shell scripts in the MPS as part of CI.

Also adds tool/check-shell-scripts for command-line use.

Shell script errors are not known to have caused defects in the MPS, but this was very cheap to implement as a side effect of #112 