### PR TITLE
Correct file name references.

### DIFF
--- a/code/pthrdext.c
+++ b/code/pthrdext.c
@@ -1,4 +1,4 @@
-/* pthreadext.c: POSIX THREAD EXTENSIONS
+/* pthrdext.c: POSIX THREAD EXTENSIONS
  *
  *  $Id$
  *  Copyright (c) 2001-2020 Ravenbrook Limited.  See end of file for license.
@@ -15,7 +15,7 @@
 #include "mpm.h"
 
 #if !defined(MPS_OS_FR) && !defined(MPS_OS_LI)
-#error "protsgix.c is specific to MPS_OS_FR or MPS_OS_LI"
+#error "pthrdext.c is specific to MPS_OS_FR or MPS_OS_LI"
 #endif
 
 #include "pthrdext.h"

--- a/code/thxc.c
+++ b/code/thxc.c
@@ -22,7 +22,7 @@
 #include "mpm.h"
 
 #if !defined(MPS_OS_XC)
-#error "protw3.c is specific to MPS_OS_XC"
+#error "thxc.c is specific to MPS_OS_XC"
 #endif
 
 #include "protxc.h"


### PR DESCRIPTION
The checks that these files are being used on the right platform contain the wrong file names.