### PR TITLE
ANSI platform builds shouldn't link pthreads.

### DIFF
--- a/code/anangc.gmk
+++ b/code/anangc.gmk
@@ -16,7 +16,7 @@ MPMPF = \
     than.c \
     vman.c
 
-LIBS = -lm -lpthread
+LIBS = -lm
 
 include gc.gmk
 

--- a/code/ananll.gmk
+++ b/code/ananll.gmk
@@ -16,7 +16,7 @@ MPMPF = \
     than.c \
     vman.c
 
-LIBS = -lm -lpthread
+LIBS = -lm
 
 include ll.gmk
 


### PR DESCRIPTION
Since this isn't using threads or POSIX locks, the `-lpthreads` should not be needed and having it only makes it easier to accidentally add some dependency on it.

[Edit by @rptb1 : @waywardmonkeys requires this change to build on WebAssembly.  See #168 and #175 .]