### PR TITLE
Unix: Use sysconf(_SC_PAGESIZE), not getpagesize()

### DIFF
--- a/code/vmix.c
+++ b/code/vmix.c
@@ -50,7 +50,7 @@
 #include <signal.h> /* sig_atomic_t */
 #include <sys/mman.h> /* see .feature.li in config.h */
 #include <sys/types.h> /* mmap, munmap */
-#include <unistd.h> /* getpagesize */
+#include <unistd.h> /* sysconf, _SC_PAGESIZE */
 
 SRCID(vmix, "$Id$");
 
@@ -59,10 +59,10 @@ SRCID(vmix, "$Id$");
 
 Size PageSize(void)
 {
-  int pageSize;
+  long pageSize;
 
   /* Find out the operating system page size */
-  pageSize = getpagesize();
+  pageSize = sysconf(_SC_PAGESIZE);
 
   /* Check the page size will fit in a Size. */
   AVER((unsigned long)pageSize <= (unsigned long)(Size)-1);

--- a/code/vmix.c
+++ b/code/vmix.c
@@ -61,7 +61,8 @@ Size PageSize(void)
 {
   long pageSize;
 
-  /* Find out the operating system page size */
+  /* Find out the operating system page size
+     (see design.mps.vm.impl.ix.page.size) */
   pageSize = sysconf(_SC_PAGESIZE);
 
   /* Check the page size will fit in a Size. */

--- a/design/vm.txt
+++ b/design/vm.txt
@@ -269,7 +269,7 @@ Unix implementation
 
 _`.impl.ix`: In ``vmix.c``.
 
-_`.impl.ix.page.size`: The page size is given by ``getpagesize()``.
+_`.impl.ix.page.size`: The page size is given by ``sysconf(_SC_PAGESIZE)``.
 
 _`.impl.ix.param`: Decodes no keyword arguments.
 

--- a/design/vm.txt
+++ b/design/vm.txt
@@ -269,7 +269,13 @@ Unix implementation
 
 _`.impl.ix`: In ``vmix.c``.
 
-_`.impl.ix.page.size`: The page size is given by ``sysconf(_SC_PAGESIZE)``.
+_`.impl.ix.page.size`: The page size is given by
+``sysconf(_SC_PAGESIZE)``.  We avoid ``getpagesize()``, which is a
+legacy function in Posix:
+
+  Applications should use the sysconf() function instead.
+
+  — `The Single UNIX ® Specification, Version 2 <https://pubs.opengroup.org/onlinepubs/7908799/xsh/getpagesize.html>`__
 
 _`.impl.ix.param`: Decodes no keyword arguments.
 


### PR DESCRIPTION
The `getpagesize()` is a legacy function and is not available in the default configurations on some platforms.

The documentation for `getpagesize()` recommends using the POSIX `sysconf(_SC_PAGESIZE)` instead.

Additionally, `sysconf(_SC_PAGESIZE)` returns a `long` rather than an `int`, so the code is updated to handle that as well.

Sources:

* https://man7.org/linux/man-pages/man2/getpagesize.2.html
* https://pubs.opengroup.org/onlinepubs/7908799/xsh/getpagesize.html