### PR TITLE
Fixing CI builds of version 1.117

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -1,0 +1,113 @@
+# .github/workflows/build-and-test.yml -- GitHub CI build and test configuration for the MPS
+#
+# Copyright (c) 2019-2022 `GitHub contributors`_ (MIT License).
+# Copyright (c) 2023 Ravenbrook Limited. See end of file for license.
+#
+# See design.mps.test.ci.
+#
+# TODO: Exclude certain branches.
+#
+# TODO: Regular builds of version branches.  See
+# <https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#onschedule>.
+
+name: build and test
+
+on:
+  - push
+  - pull_request
+  # Also run when triggered manually, e.g. by tool/github-ci-kick
+  # <https://docs.github.com/en/actions/managing-workflow-runs/manually-running-a-workflow>
+  - workflow_dispatch
+
+jobs:
+
+  posix:
+
+    # The build matrix for GitHub CI on Posix platforms
+    #
+    # See design.mps.tests.ci.github.platforms.
+    #
+    # FreeBSD and ARM64 targets are in Travis CI, configured by
+    # .travis.yml.
+    #
+    # See <https://docs.github.com/en/actions/using-jobs/using-a-matrix-for-your-jobs#using-a-matrix-strategy>.
+    
+    strategy:
+      matrix:
+        os: [ubuntu-latest, macos-latest]
+        compiler: [clang, gcc]
+        exclude:
+          - os: macos-latest
+            compiler: gcc
+
+    runs-on: ${{ matrix.os }}
+
+    # See design.mps.tests.ci.run.posix.
+    steps:
+    - uses: actions/checkout@v3
+    - run: CC=${{ matrix.compiler }} ./configure
+    - run: make
+    - run: make test
+
+  windows:
+
+    runs-on: windows-latest
+
+    # See design.mps.tests.ci.run.windows.
+    #
+    # The path to Visual Studio is documented at
+    # <https://github.com/actions/runner-images/blob/e6fcf60b8e6c0f80a065327eaefe836881c28b68/images/win/Windows2022-Readme.md?plain=1#L215>.
+
+    steps:
+    - uses: actions/checkout@v3
+    - run: |
+         call "C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Auxiliary\Build\vcvarsall.bat" x64
+         cd code
+         nmake /f w3i6mv.nmk all testci testansi testpollnone
+      shell: cmd
+
+
+# A. REFERENCES
+#
+# [GitHub CI] "About continuous integration"; <https://docs.github.com/en/actions/automating-builds-and-tests/about-continuous-integration>.
+#
+#
+# B. DOCUMENT HISTORY
+#
+# 2023-01-11 RB Adapted from <https://github.com/actions/starter-workflows/blob/9f245d9aba830ad16a097a45c78331a05114d815/ci/c-cpp.yml>.
+# 2023-01-15 RB Added licence and document history.
+#
+#
+# C. COPYRIGHT AND LICENSE
+#
+# NOTE: This is the `MIT Licence <https://opensource.org/licenses/MIT>`_
+# inherited from
+# <https://github.com/actions/starter-workflows/blob/9f245d9aba830ad16a097a45c78331a05114d815/ci/c-cpp.yml> and not the usual licence for the MPS.
+#
+# Copyright (c) 2019-2022 `GitHub contributors`_.
+# Copyright (c) 2023 Ravenbrook Limited <https://www.ravenbrook.com/>.
+#
+# Permission is hereby granted, free of charge, to any person
+# obtaining a copy of this software and associated documentation files
+# (the "Software"), to deal in the Software without restriction,
+# including without limitation the rights to use, copy, modify, merge,
+# publish, distribute, sublicense, and/or sell copies of the Software,
+# and to permit persons to whom the Software is furnished to do so,
+# subject to the following conditions:
+# 
+# The above copyright notice and this permission notice shall be
+# included in all copies or substantial portions of the Software.
+# 
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+# EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+# MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+# NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+# BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+# ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+# CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+#
+# .. _GitHub contributors: https://github.com/actions/starter-workflows/commits/1d9d6d7fb0a8a27ef98efbbfa9689cd14c906383/ci/c-cpp.yml
+#
+#
+# $Id$

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,24 +1,53 @@
 # .travis.yml -- Travis CI configuration for the MPS
-# $Id$
-# See <http://about.travis-ci.org/docs/user/languages/c/>.
-language: c
+#
+# Copyright (c) 2013-2023 Ravenbrook Limited. See end of file for license.
+#
+# See design.mps.test.ci.
+
+# Some branches don't need builds.  Add them here to avoid using build
+# resources and unnecessary build messages.  See
+# <https://docs.travis-ci.com/user/conditions-v1>.
+if: NOT branch IN (branch/2023-01-11/github-ci)
+
+language: c # see <https://docs.travis-ci.com/user/languages/c/>.
+
+# The build matrix for Travis CI
+#
+# See design.mps.tests.ci.travis.platforms.
+#
+# Most x86_64/amd64 builds are in GitHub CI, configured by
+# .github/workflows/build-and-test.yml.
+
 os:
   - freebsd
   - linux
-  - osx
-  # See "include" section for Windows
 arch:
-  - amd64
   - arm64
 compiler:
   - clang
   - gcc
+
+script: # see design.mps.test.ci.run.posix
+- ./configure --prefix=$PWD/prefix && make install && make test
+
 matrix:
+
+  # Extra build jobs to add to the matrix
   include:
-    - os: windows
+
+    # GitHub CI does not provide FreeBSD
+    # <https://docs.github.com/en/actions/using-github-hosted-runners/about-github-hosted-runners#supported-runners-and-hardware-resources>
+    # on any architecture, so we add it here for amd64.  See also
+    # design.mps.tests.ci.travis.platforms.
+
+    - os: freebsd
       arch: amd64
-      compiler: clang # This is a lie since we invoke MV (Microsoft C)
-      script: MSYS2_ARG_CONV_EXCL='*' cmd /c 'code\w3i6mv.bat'
+      compiler: clang
+    - os: freebsd
+      arch: amd64
+      compiler: gcc
+
+  # Specific combinations to exclude from the matrix
   exclude:
     - os: osx
       compiler: gcc
@@ -35,5 +64,44 @@ notifications:
 #before_install:
 #  - if test "$TRAVIS_OS_NAME" = "linux"; then sudo apt-get -qq update; fi
 #  - if test "$TRAVIS_OS_NAME" = "linux"; then sudo apt-get install -y gcc-4.7; fi
-script:
-- ./configure --prefix=$PWD/prefix && make install && make test
+
+
+# A. REFERENCES
+#
+#
+# B. DOCUMENT HISTORY
+#
+# 2013-05-19 RB Created.
+# 2023-01-15 RB Added licence and (note) document history.
+#
+#
+# C. COPYRIGHT AND LICENSE
+#
+# Copyright (C) 2013-2023 Ravenbrook Limited <https://www.ravenbrook.com/>.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are
+# met:
+#
+# 1. Redistributions of source code must retain the above copyright
+#    notice, this list of conditions and the following disclaimer.
+#
+# 2. Redistributions in binary form must reproduce the above copyright
+#    notice, this list of conditions and the following disclaimer in the
+#    documentation and/or other materials provided with the
+#    distribution.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+# IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED
+# TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+# PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+# HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+# SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+# LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+# DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+# THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#
+#
+# $Id$

--- a/design/tests.txt
+++ b/design/tests.txt
@@ -56,6 +56,53 @@ _`.test.zcoll`: Collection scheduling, and collection feedback.
 _`.test.zmess`: Message lifecycle and finalization messages.
 
 
+Test database
+-------------
+
+_`.db`: The automated tests are described in the test database
+(tool/testcases.txt).
+
+_`.db.format`: This is a self-documenting plain-text database which
+gives for each test case its name and an optional set of features. For
+example the feature ``=P`` means that the test case requires polling
+to succeed, and therefore is expected to fail in build configurations
+without polling (see design.mps.config.opt.poll_).
+
+_`.db.format.simple`: The format must be very simple because the test
+runner on Windows is written as a batch file (.bat), in order to avoid
+having to depend on any tools that are did not come as standard with
+Windows XP, and batch files are inflexible. (But note that we no
+longer support Windows XP, so it would now be possible to rewrite the
+test runner in PowerShell if we thought that made sense.)
+
+_`.db.testrun`: The test runner (tool/testrun.sh on Unix or
+tool/testrun.bat on Windows) parses the test database to work out
+which tests to run according to the target. For example the
+``testpollnone`` target must skip all test cases with the ``P``
+feature.
+
+
+Test runner
+-----------
+
+_`.runner.req.automated`: The test runner must execute without user
+interaction, so that it can be used for continuous integration.
+
+_`.runner.req.output.pass`: Test cases are expected to pass nearly all the
+time, and in these cases we almost never want to see the output, so
+the test runner must suppress the output for passing tests.
+
+_`.runner.req.output.fail`: However, if a test case fails then the
+test runner must preserve the output from the failing test, including
+the random seed (see `.randomize.seed`_), so that this can be analyzed
+and the test repeated. Moreover, it must print the output from the
+failing test, so that if the test is being run on a `continuous
+integration`_ system (see `.ci`_), then the output of the failing
+tests is included in the failure report. (See job003489_.)
+
+.. _job003489: https://www.ravenbrook.com/project/mps/issue/job003489/
+
+
 Performance test
 ----------------
 
@@ -141,6 +188,158 @@ _`.new.manual`: Edit manual/source/code-index.rst and add the new test
 case to the "Automated test cases" section.
 
 
+Continuous integration
+----------------------
+
+[This section might need to become a document in its own right.  CI
+has grown in importance and complexity.  RB 2023-01-15]
+
+_`.ci`: Ravenbrook uses both `GitHub CI`_ and `Travis CI`_ for
+continuous integration of the MPS via GitHub.
+
+.. _Travis CI: https://travis-ci.com/
+
+.. _GitHub CI: https://docs.github.com/en/actions/automating-builds-and-tests/about-continuous-integration
+
+[This section needs: definition of CI goals and requirements, what we
+need CI to do and why, how the testci target meets those
+requirements.  'taint really a design without this.  Mention how CI
+supports the pull request merge procedure (except that exists on a
+separate branch at the moment).  RB 2023-01-15]
+
+[Need to discuss compilers and toolchains.  RB 2023-01-15]
+
+_`.ci.run.posix`: On Posix systems where we have autoconf, the CI
+services run commands equivalent to::
+
+  ./configure
+  make install
+  make test
+
+which execises the testci target, as defined by `Makefile.in
+<../Makefile.in>`_ in the root of the MPS tree.
+
+_`.ci.run.windows`: On Windows the CI services run commands that do at
+least::
+
+  make /f w3i6mv.nmk all testci
+
+as defined by the `.ci.github.config`_.
+
+_`.ci.run.other.targets`: On some platforms we arrange to run the testansi,
+testpollnone, testratio, and testscheme targets.  [Need to explain
+why, where, etc.  RB 2023-01-15]
+
+_`.ci.run.other.checks`: We could also run various non-build checks
+using CI to check:
+
+- document formatting
+- shell script syntax
+
+[In the branch of writing, these do not yet exist.  They are the
+subject of `GitHub pull request #113
+<https://github.com/Ravenbrook/mps/pull/112>`_ of
+branch/2023-01-13/rst-check.  When merged, they can be linked.  RB
+2023-01-15]
+
+_`.ci.when:`: CI is triggered on the `mps GitHub repo`_ by:
+
+- commits (pushes)
+- new pull requests
+- manually, using tools (see `.ci.tools`_)
+
+.. _mps GitHub repo: https://github.com/ravenbrook/mps
+
+_`.ci.results`: CI results are visible via the GitHub web interface:
+
+- in pull requests, under "Checks",
+
+- on the `branches page <https://github.com/Ravenbrook/mps/branches>`_
+  as green ticks or red crosses that link to details.
+
+as well as in logs specific to the type of CI.
+
+_`.ci.results.travis`: Results from Travis CI can be found at the
+`Travis CI build history for the MPS GitHub repo
+<https://app.travis-ci.com/github/Ravenbrook/mps/builds>`_.
+
+_`.ci.results.github`: Results from GitHub CI can be found at `build
+and test actions on the Actions tab at the Ravenbrook GitHub repo
+<https://github.com/Ravenbrook/mps/actions/workflows/build-and-test.yml>`_.
+
+_`.ci.github`: [Insert overview of GitHub CI here.  RB 2023-01-15]
+
+_`.ci.github.platforms`: GitHub provides runners_ for Linux, Windows,
+and macOS, but only on x86_64.  See `.ci.travis.platforms`_ for ARM64
+and FreeBSD.
+
+.. _runners: https://docs.github.com/en/actions/using-github-hosted-runners/about-github-hosted-runners#supported-runners-and-hardware-resources
+
+_`.ci.github.config`: GitHub CI is configured using the
+`build-and-test.yml <../.github/workflows/build-and-test.yml>`_ file
+in the .github/workflows directory of the MPS tree.
+
+_`.ci.travis`: [Insert overview of Travis CI here.  RB 2023-01-15]
+
+_`.ci.travis.platforms`: Where possible, we use `GitHub CI`_ for
+platforms, because `Travis CI is slow and expensive`_.  However
+`GitHub CI`_ does not provide ARM64 or FreeBSD, so we use `Travis CI`_
+for those.
+
+.. _Travis CI is slow and expensive: https://github.com/Ravenbrook/mps/issues/109
+
+_`.ci.travis.config`: Travis is configured using the `.travis.yml
+<../.travis.yml>`_ file at top level of the MPS tree.
+
+_`.ci.tools`: The MPS tree contains some simple tools for managing CI
+without the need to install whole packages such as the GitHub CLI or
+Travis CI's Ruby gem.
+
+_`.ci.tools.kick`: `tool/github-ci-kick <../tool/github-ci-kick>`_ and
+`tool/travis-ci-kick <../tool/travis-ci-kick>`_ both trigger CI builds
+without the need to push a change or make a pull request in the `mps
+GitHub repo`_.  In particular, they are useful for applying CI to work
+that was pushed while CI was disabled, for whatever reason.
+
+
+MMQA tests
+----------
+
+_`.mmqa`: The Memory Management Quality Assurance test suite is
+another suite of test cases.
+
+_`.mmqa.why`: The existence of two test suites originates in the
+departmental structure at Harlequin Ltd where the MPS was originally
+developed. Tests written by members of the Memory Management Group
+went into the code directory along with the MPS itself, while tests
+written by members of the Quality Assurance Group went into the test
+directory. (Conway's Law states that "organizations which design
+systems … are constrained to produce designs which are copies of the
+communication structures of these organizations" [Conway_1968]_.)
+
+_`.mmqa.run`: See test/README for how to run the MMQA tests.
+
+
+Other tests
+-----------
+
+_`.coverage`: The program tool/testcoverage compiles the MPS with
+coverage enabled, runs the smoke tests (`.target.testrun`_) and
+outputs a coverage report.
+
+_`.opendylan`: The program tool/testopendylan pulls Open Dylan from
+GitHub and builds it against the MPS.
+
+
+References
+----------
+
+.. [Conway_1968]
+   "How do Committees Invent?";
+   Melvin E. Conway; *Datamation* 14:5, pp. 28–31; April 1968;
+   <http://www.melconway.com/Home/Committees_Paper.html>
+
+
 Document History
 ----------------
 
@@ -156,8 +355,11 @@ Document History
 
 - 2018-06-15 GDR_ Procedure for adding a new smoke test.
 
-.. _RB: http://www.ravenbrook.com/consultants/rb/
-.. _GDR: http://www.ravenbrook.com/consultants/gdr/
+- 2023-01-15 RB_ Bringing CI section up to date with Travis
+  configuration.  Removing obsolete Jenkins info.  Adding GitHub CI.
+
+.. _RB: https://www.ravenbrook.com/consultants/rb/
+.. _GDR: https://www.ravenbrook.com/consultants/gdr/
 
 
 Copyright and License
@@ -178,26 +380,16 @@ met:
    notice, this list of conditions and the following disclaimer in the
    documentation and/or other materials provided with the distribution.
 
-#. Redistributions in any form must be accompanied by information on how
-   to obtain complete source code for this software and any
-   accompanying software that uses this software.  The source code must
-   either be included in the distribution or be available for no more than
-   the cost of distribution plus a nominal fee, and must be freely
-   redistributable under reasonable conditions.  For an executable file,
-   complete source code means the source code for all modules it contains.
-   It does not include source code for modules or files that typically
-   accompany the major components of the operating system on which the
-   executable file runs.
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-**This software is provided by the copyright holders and contributors
-"as is" and any express or implied warranties, including, but not
-limited to, the implied warranties of merchantability, fitness for a
-particular purpose, or non-infringement, are disclaimed.  In no event
-shall the copyright holders and contributors be liable for any direct,
-indirect, incidental, special, exemplary, or consequential damages
-(including, but not limited to, procurement of substitute goods or
-services; loss of use, data, or profits; or business interruption)
-however caused and on any theory of liability, whether in contract,
-strict liability, or tort (including negligence or otherwise) arising in
-any way out of the use of this software, even if advised of the
-possibility of such damage.**
+.. end

--- a/tool/github-ci-kick
+++ b/tool/github-ci-kick
@@ -1,0 +1,120 @@
+#!/bin/sh
+# tool/github-ci-kick -- kick off a build at GitHub CI
+# Richard Brooksby, Ravenbrook Limited, 2023-01-15
+#
+# Copyright (c) 2023 Ravenbrook Limited. See end of file for license.
+#
+# This shell script uses the GitHub REST API to kick off a build on
+# the GitHub CI servers [GITHUB].  The build will be run using the
+# GitHub CI configuration at the commit (in
+# .github/workflows/build-and-test.yml).
+#
+# TODO: What about other workflows such as rst-check.yml?  Perhaps
+# this script should kick them all.
+#
+# See also tool/travis-ci-kick.
+#
+# You can achieve the same thing using the GitHub CLI, if you have
+# that installed
+# <https://docs.github.com/en/actions/managing-workflow-runs/manually-running-a-workflow#running-a-workflow-using-github-cli>.
+# This script is intended to help with automation and so avoids
+# depending on that.  [There's a hidden policy implied here.  RB
+# 2023-01-15]
+#
+# To get a token for this script for the Ravenbrook MPS repo at
+# GitHub, first see
+# <https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/creating-a-personal-access-token#creating-a-fine-grained-personal-access-token>
+# but overlay these details:
+#
+# 1. In "Resource owner" choose "Ravenbrook".  You must be a member of
+#    the GitHub Ravenbrook organisation.
+#
+# 2. In "Repository access" choose "Only select repositories" and the
+#    "Ravenbrook/mps" repository.
+#
+# 3. In "Permissions" expand "Repository permissions" and under
+#    "Actions" choose "Read and write".
+#
+# NOTE: This script could use the GitHub CLI, but that would require
+# it to be installed by the user.
+#
+# TODO: Convert to Python for use from Windows?
+#
+# TODO: Make -t optional by getting AUTH-TOKEN from somewhere (secure).
+
+set -e # exit on error
+
+# defaults
+branch="master"
+org="Ravenbrook"
+repo="mps"
+
+usage() {
+    echo 1>&2 "Usage: ${0} [-o ORG] [-r REPO] [-b BRANCH] -t AUTH-TOKEN"
+    exit 1
+}    
+
+while getopts c:b:r:t: flag; do
+    case "${flag}" in
+	b) branch="${OPTARG}";;
+	o) org="${OPTARG}";;
+	r) repo="${OPTARG}";;
+	t) auth="${OPTARG}";;
+	*) usage;;
+    esac
+done
+
+test -z "${auth}" && usage
+
+curl --silent --show-error \
+  --request POST --data @- \
+  --header "Accept: application/vnd.github+json" \
+  --header "Authorization: Bearer ${auth}"\
+  --header "X-GitHub-Api-Version: 2022-11-28" \
+  "https://api.github.com/repos/${org}/${repo}/actions/workflows/build-and-test.yml/dispatches" \
+  <<-EOF
+{
+  "ref": "${branch}"
+}
+EOF
+
+
+# A. REFERENCES
+#
+# [GitHub] "Create a workflow dispatch event"; <https://docs.github.com/en/rest/actions/workflows?apiVersion=2022-11-28#create-a-workflow-dispatch-event>.
+#
+#
+# B. DOCUMENT HISTORY
+#
+# 2023-01-15 RB Created.
+#
+# C. COPYRIGHT AND LICENSE
+#
+# Copyright (C) 2023 Ravenbrook Limited <https://www.ravenbrook.com/>.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are
+# met:
+#
+# 1. Redistributions of source code must retain the above copyright
+#    notice, this list of conditions and the following disclaimer.
+#
+# 2. Redistributions in binary form must reproduce the above copyright
+#    notice, this list of conditions and the following disclaimer in the
+#    documentation and/or other materials provided with the
+#    distribution.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+# IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED
+# TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+# PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+# HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+# SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+# LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+# DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+# THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#
+#
+# $Id$

--- a/tool/travis-ci-kick
+++ b/tool/travis-ci-kick
@@ -1,0 +1,117 @@
+#!/bin/sh
+# tool/travis-ci-kick -- kick off a build at Travis CI
+# Richard Brooksby, Ravenbrook Limited, 2023-01-15
+#
+# Copyright (c) 2023 Ravenbrook Limited. See end of file for license.
+#
+# This shell script uses the Travis CI REST API V3 to kick off a build
+# on the Travis CI servers.  The build will be run using the Travis CI
+# configuration at the commit (in .travis.yml).
+#
+# See also tool/github-ci-kick.
+#
+# To get a token for this script, visit
+# <https://app.travis-ci.com/account/preferences> and copy your token
+# from "API authentication".
+#
+# TODO: Extend this script to take MPS platform codes and kick off the
+# appropriate build, overriding the (possibly nonexistent) Travis Ci
+# config.  See [TRAVIS].
+#
+# TODO: Convert to Python for use from Windows?
+#
+# TODO: Make -t optional by getting AUTH-TOKEN from somewhere (secure).
+
+set -e # exit on error
+
+# defaults
+branch="master"
+org="Ravenbrook"
+repo="mps"
+
+usage() {
+    echo 1>&2 "Usage: ${0} [-o ORG] [-r REPO] [-b BRANCH] [-c COMMIT-SHA] -t AUTH-TOKEN"
+    exit 1
+}    
+
+while getopts c:b:r:t: flag; do
+    case "${flag}" in
+	c) commit="${OPTARG}";;
+	b) branch="${OPTARG}";;
+	o) org="${OPTARG}";;
+	r) repo="${OPTARG}";;
+	t) auth="${OPTARG}";;
+	*) usage;;
+    esac
+done
+
+test -z "${auth}" && usage
+
+# If the field "sha" is omitted, Travis CI builds the tip of the
+# branch [TRAVIS].
+if test -z "${commit}"; then
+    cat <<-EOF
+{
+  "request": {
+    "branch":"${branch}"
+  }
+}
+EOF
+else
+    cat <<EOF
+{
+  "request": {
+    "branch": "${branch}",
+    "sha": "${commit}"
+  }
+}
+EOF
+fi |
+curl --silent --show-error \
+     --request POST --data @- \
+     --header "Content-Type: application/json" \
+     --header "Accept: application/json" \
+     --header "Travis-API-Version: 3" \
+     --header "Authorization: token ${auth}" \
+     "https://api.travis-ci.com/repo/${org}%2F${repo}/requests"
+
+
+# A. REFERENCES
+#
+# [Travis] "Triggering builds with API V3"; <https://github.com/travis-ci/docs-travis-ci-com/blob/859062b7cdcab69fc9691924ad6a031cf0819cf8/user/triggering-builds.md>.
+#
+#
+# B. DOCUMENT HISTORY
+#
+# 2023-01-15 RB Created.
+#
+# C. COPYRIGHT AND LICENSE
+#
+# Copyright (C) 2023 Ravenbrook Limited <https://www.ravenbrook.com/>.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are
+# met:
+#
+# 1. Redistributions of source code must retain the above copyright
+#    notice, this list of conditions and the following disclaimer.
+#
+# 2. Redistributions in binary form must reproduce the above copyright
+#    notice, this list of conditions and the following disclaimer in the
+#    documentation and/or other materials provided with the
+#    distribution.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+# IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED
+# TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+# PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+# HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+# SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+# LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+# DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+# THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#
+#
+# $Id$


### PR DESCRIPTION
Working on #124 .

Work plan:
1. Cherry pick CI changes from master using procedure described here https://github.com/Ravenbrook/mps/issues/190#issue-1610125376
2. Fix up build issues, as far as possible by cherry picking from master.