### PR TITLE
Automatically checking copyright dates in copyright notices

### DIFF
--- a/tool/check-copyright-dates
+++ b/tool/check-copyright-dates
@@ -4,8 +4,8 @@
 #
 # Copyright (c) 2023 Ravenbrook Limited.  See end of file for license.
 #
-# FIXME: Only works for Ravenbrook copyrights.  Should perhaps look
-# for the last notice in a group of lines.
+# Only works for Ravenbrook copyrights.  TODO: Should perhaps look for
+# the last notice in a group of lines.
 
 this_year="$(date '+%Y')"
 


### PR DESCRIPTION
Experimental script to check the copyright dates in notices such as "Copyright (C) 1997-2023" and in particular that the end date is consistent with when the file was last modified in Git's history.  This could be incorporated into CI.