### PR TITLE
Avoid using `sizeof('\0')` to compute size for NUL-terminator.

### DIFF
--- a/code/event.h
+++ b/code/event.h
@@ -84,7 +84,7 @@ extern Word EventKindControl;
     size_t _string_len = (length); \
     size_t size; \
     AVER(_string_len <= EventStringLengthMAX); \
-    size = offsetof(Event##name##Struct, f1) + _string_len + sizeof('\0'); \
+    size = offsetof(Event##name##Struct, f1) + _string_len + 1 /* NUL */; \
     EVENT_BEGIN(name, size) \
       _event->f0 = (p0); \
       (void)mps_lib_memcpy(_event->f1, (string), _string_len); \

--- a/code/eventcom.h
+++ b/code/eventcom.h
@@ -91,7 +91,7 @@ typedef void *EventFP;                  /* pointer to C object */
 typedef Addr EventFA;                   /* address on the heap */
 typedef Word EventFW;                   /* word */
 typedef unsigned EventFU;               /* unsigned integer */
-typedef char EventFS[EventStringLengthMAX + sizeof('\0')]; /* string */
+typedef char EventFS[EventStringLengthMAX + 1 /* NUL */]; /* string */
 typedef double EventFD;                 /* double */
 typedef unsigned char EventFB;          /* Boolean */
 


### PR DESCRIPTION
The expression `sizeof('\0')` evaluates to `sizeof(int)`, which does not reflect the intent in the code. It has been replaced with `1 /* NUL */` for clarity.

This issue was originally reported by наб <nabijaczleweli@nabijaczleweli.xyz> who also proposed this patch.

Fixes #276 