### PR TITLE
ci: Update `actions/checkout` to `v4` from `v3`.

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -44,7 +44,7 @@ jobs:
 
     # See design.mps.tests.ci.run.posix.
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - run: CC=${{ matrix.compiler }} ./configure
     - run: make
     - run: make test
@@ -59,7 +59,7 @@ jobs:
     # <https://github.com/actions/runner-images/blob/e6fcf60b8e6c0f80a065327eaefe836881c28b68/images/win/Windows2022-Readme.md?plain=1#L215>.
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - run: |
          call "C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Auxiliary\Build\vcvarsall.bat" x64
          cd code

--- a/.github/workflows/fixme-check.yml
+++ b/.github/workflows/fixme-check.yml
@@ -17,5 +17,5 @@ jobs:
   check-fixme:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - run: tool/check-fixme

--- a/.github/workflows/rst-check.yml
+++ b/.github/workflows/rst-check.yml
@@ -16,7 +16,7 @@ jobs:
   check-rst:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Install docutils
         run: sudo apt-get install -y docutils
       - name: Check reStructuredText syntax

--- a/.github/workflows/shell-script-check.yml
+++ b/.github/workflows/shell-script-check.yml
@@ -16,7 +16,7 @@ jobs:
   check-shell-scripts:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Install shellcheck
         run: sudo apt-get install -y shellcheck
       - name: Check shell scripts


### PR DESCRIPTION
This updates internally to using Node 20 and removes some deprecation notices within the GitHub Actions UI about Node 16 being deprecated.