### PR TITLE
Updating checkout actions to one permitted by GitHub

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -44,7 +44,7 @@ jobs:
 
     # See design.mps.tests.ci.run.posix.
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - run: CC=${{ matrix.compiler }} ./configure
     - run: make
     - run: make test
@@ -59,7 +59,7 @@ jobs:
     # <https://github.com/actions/runner-images/blob/e6fcf60b8e6c0f80a065327eaefe836881c28b68/images/win/Windows2022-Readme.md?plain=1#L215>.
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - run: |
          call "C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Auxiliary\Build\vcvarsall.bat" x64
          cd code

--- a/.github/workflows/fixme-check.yml
+++ b/.github/workflows/fixme-check.yml
@@ -17,5 +17,5 @@ jobs:
   check-fixme:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - run: tool/check-fixme

--- a/.github/workflows/rst-check.yml
+++ b/.github/workflows/rst-check.yml
@@ -16,7 +16,7 @@ jobs:
   check-rst:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Install docutils
         run: sudo apt-get install -y docutils
       - name: Check reStructuredText syntax


### PR DESCRIPTION
GitHub builds started failing on MPS branches because they referenced a checkout action that has been [forbidden by GitHub for security](https://github.blog/changelog/2024-03-07-github-actions-all-actions-will-run-on-node20-instead-of-node16-by-default/).

The scope of this branch is likely to expand to cover other problems with the automated GitHub builds, which appear to have rotted somewhat.