### PR TITLE
Tell GitHub not to cancel builds in the posix matrix

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -33,6 +33,7 @@ jobs:
     # See <https://docs.github.com/en/actions/using-jobs/using-a-matrix-for-your-jobs#using-a-matrix-strategy>.
     
     strategy:
+      fail-fast: false # don't cancel all builds when one build fails
       matrix:
         os: [ubuntu-latest, macos-latest]
         compiler: [clang, gcc]


### PR DESCRIPTION
Fixes #295 according to [Handling failures](https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/running-variations-of-jobs-in-a-workflow#handling-failures).