### PR TITLE
Removing use of deprecated alias of VersionChange

### DIFF
--- a/manual/source/extensions/mps/__init__.py
+++ b/manual/source/extensions/mps/__init__.py
@@ -12,7 +12,7 @@ from docutils import nodes, transforms
 from docutils.parsers.rst import Directive
 from docutils.parsers.rst.directives.admonitions import BaseAdmonition
 from sphinx import addnodes
-from sphinx.directives.other import VersionChange
+from sphinx.domains.changeset import VersionChange
 from sphinx.domains import Domain
 from sphinx.domains.changeset import versionlabels
 from sphinx.locale import admonitionlabels


### PR DESCRIPTION
Deprecated alias `sphinx.directives.other.VersionChange` was removed in Sphinx 8 <https://www.sphinx-doc.org/en/master/changes/8.0.html#release-8-0-0-released-jul-29-2024> and this breaks the manual build.

This also breaks manual builds on Read The Docs, e.g. https://readthedocs.org/projects/memory-pool-system/builds/26405165/

Update to the recommended `sphinx.domains.changeset.VersionChange`.