### PR TITLE
Fixing warnings uncovered by Clang 15.0 on macOS 14.7.1.

### DIFF
--- a/code/trans.c
+++ b/code/trans.c
@@ -163,8 +163,8 @@ Res TransformAddOldNew(Transform transform,
      lists (old_list, new_list), using ArenaRead.  Insisting on
      parking keeps things simple. */
   arena = transform->arena;
-  AVER(ArenaGlobals(arena)->clamped);
-  AVER(arena->busyTraces == TraceSetEMPTY);
+  AVER(ArenaGlobals(arena)->clamped);           /* .assume.parked */
+  AVER(arena->busyTraces == TraceSetEMPTY);     /* .assume.parked */
 
   res = TableGrow(transform->oldToNew, count);
   if (res != ResOK)

--- a/code/trans.c
+++ b/code/trans.c
@@ -151,7 +151,6 @@ Res TransformAddOldNew(Transform transform,
 {
   Res res;
   Index i;
-  Count added = 0;
   Arena arena;
 
   AVERT(Transform, transform);
@@ -190,8 +189,6 @@ Res TransformAddOldNew(Transform transform,
     AVER(res != ResFAIL); /* It's a static error to add the same old twice. */
     if (res != ResOK)
       return res;
-    
-    ++added;
   }
 
   AVERT(Transform, transform);


### PR DESCRIPTION
Fixing the build errors seen in e.g. [this GitHub build output](https://github.com/Ravenbrook/mps/actions/runs/12034763420/job/33552102514#step:4:260) which says
```
/Users/runner/work/mps/mps/code/trans.c:154:9: error: variable 'added' set but not used [-Werror,-Wunused-but-set-variable]
(2 failures)
  Count added = 0;
```

The "added" count variable has been around since [Perforce changelist 178798](https://info.ravenbrook.com/infosys/cgi/perfbrowse.cgi?%40describe+178798) in 2012, before transforms were released to Configura in MPS 1.110. It does not appear to ever have been used for anything.